### PR TITLE
Make buttons full width for smaller screens

### DIFF
--- a/app/assets/sass/elements/_buttons.scss
+++ b/app/assets/sass/elements/_buttons.scss
@@ -3,9 +3,13 @@
 
 .button {
   @include button ($button-colour);
+  @include box-sizing (border-box);
   margin: 0 $gutter-half $gutter-half 0;
   padding: em(10) em(15) em(5) em(15);
   vertical-align: top;
+  @include media (mobile) {
+    width: 100%;
+  }
 }
 
 // Fix unwanted button padding in Firefox

--- a/app/assets/sass/elements/_forms.scss
+++ b/app/assets/sass/elements/_forms.scss
@@ -149,13 +149,6 @@ fieldset {
   margin: -2px 5px 0 0;
 }
 
-// Buttons
-.form .button {
-  @include media(mobile) {
-    width: 100%;
-  }
-}
-
 
 // Form validation
 @import "forms/form-validation";


### PR DESCRIPTION
These changes are the same as those in a PR for GOV.UK elements: https://github.com/alphagov/govuk_elements/pull/63/files

For smaller screens, buttons are now full width.
Button styles are removed from the _forms.scss file.

@timpaul @tombye 