### PR TITLE
Update Grunt SASS for compatibility with Node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-nodemon": "0.3.0",
-    "grunt-sass": "0.16.1",
+    "grunt-sass": "0.18.0",
     "grunt-text-replace": "0.3.12",
     "grunt-concurrent": "0.4.3"
   }


### PR DESCRIPTION
By default Brew installs Node 0.12 which doesn't work with the version of Node SASS being used, which is only compatible with versions up to 0.10.

This commit updates the version of Grunt SASS to [0.18.0](https://github.com/sindresorhus/grunt-sass/releases/tag/v0.18.0), which incorporates Node SASS version [2.0.0](https://github.com/sass/node-sass/releases/tag/v2.0.0), which _is_ compatible with Node 0.12.