### PR TITLE
Add interactivity via express cookies

### DIFF
--- a/app/defaults.js
+++ b/app/defaults.js
@@ -1,0 +1,7 @@
+
+
+defaults = {
+  // Default values to use if the user doesn't enter anything go here.
+}
+
+module.exports = defaults;

--- a/app/presenters.js
+++ b/app/presenters.js
@@ -1,0 +1,6 @@
+
+presenters = {
+  // Any changes to a value between the user entering it and it being displayed.
+}
+
+module.exports = presenters;

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,3 +1,5 @@
+var user_data = require('../lib/user_data.js');
+
 module.exports = {
   bind : function (app) {
 
@@ -9,7 +11,11 @@ module.exports = {
       res.render('examples/template-data', { 'name' : 'Foo' });
     });
 
-    // add your routes here
+    app.get('/reset', function(req, res) {
+      user_data.clear(req, res);
+      res.redirect('/')
+    });
 
+    // add your routes here
   }
 };

--- a/docs/interactivity.md
+++ b/docs/interactivity.md
@@ -1,0 +1,71 @@
+# Interactivity
+
+Prototypes should be simple, and use simple hardcoded data where possible, however sometimes it helps to use a few mirrors and a little smoke to fake a more sophisticated backend can make for a more engaging and interesting demonstration.
+
+## Form values
+
+If a form is submitted to a route, the prototype kit will automatically store all of the named fields in the form and then show the page associated with that URI.
+
+For example, given the following in `views/index.html`:
+
+```html
+<form action="/extras" method="POST">
+  <div class="form-group">
+    <label for="radio-1"><input id="radio-1" type="radio" name="order" value="Sausage, egg and chips" checked="true"></input>Sausage, egg and chips</label>
+    <label for="radio-2"><input id="radio-2" type="radio" name="order" value="Bacon roll"></input>Bacon roll</label>
+    <label for="radio-3"><input id="radio-3" type="radio" name="order" value="Jam and Toast"></input>Jam and toast</label>
+  </div>
+  <button class="button">Order up!</button>
+</form>
+```
+
+From then on, all of the submitted values will be available inside [the other pages](making-pages) in the application. So all you need to add is `views/extras.html`:
+
+```html
+<h2>Choose extras for your {{order}}</h2>
+```
+
+And you can reflect the users choices.
+
+## Clearing stored values
+
+Choices will be overridden automatically if the user goes through the same page twice, but it may be useful to automatically clear them occasionally. That can be done in [routes.js](../app/routes.js) like so:
+
+```javascript
+var user_data = require(__dirname + '../lib/user_data.js');
+// ...
+
+app.get('/reset', function (req, res) {
+  user_data.clear(req, res);
+  res.render('index');
+});
+
+```
+
+## Custom rendering
+
+If you need to change the way that something the user has entered has been displayed, it may be worth considering whether this idea is out of scope for a prototype, or could be worked around some other way.
+
+If you still need to, and are comfortable enough with javascript to be able to describe how to do the modification, you can add a new mapping to the [presenters](../app/presenters.js) object.
+
+Given the following in `views/confirm.html`
+
+```html
+<form action="/checkout" method="POST">
+  <label for="amount" class='form-label'><input type="number" id="amount" name="amount"></input> pennies</label>
+</form>
+```
+
+You can add a presenter for amount like this:
+
+```javascript
+presenters = {
+  "amount" : function (amount) { return "£" + amount / 100 }
+}
+```
+
+And in `views/checkout.html`, you can display the amount in pounds back to the user:
+
+```html
+  <p>You paid {{amount}}.</p>
+```

--- a/lib/user_data.js
+++ b/lib/user_data.js
@@ -1,0 +1,28 @@
+var util = require('util')
+
+module.exports = {
+  clear: function(req, res) {
+    console.log("Clearing all user values.")
+    for (cookie in req.cookies) {
+      if (req.cookies.hasOwnProperty(cookie)) {
+      res.clearCookie(cookie);
+      }
+    }
+  },
+
+  form_to_cookie: function(presenters) {
+    return function(req, res, next) {
+      if (req.method=="POST") {
+        console.log("Adding " + util.inspect(req.body) + " to the cookies.")
+        for (key in req.body) {
+          if (req.body.hasOwnProperty(key) && req.body[key]) {
+            var raw_value = req.body[key]
+            var value = presenters[key] ? presenters[key](raw_value) : raw_value
+            res.cookie(key, value);
+          }
+        }
+      }
+      next();
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "govuk_template_mustache": "~0.12.0",
     "node-sass": "2.1.1",
     "grunt": "0.4.5",
+    "merge": "^1.2.0",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-copy": "0.5.0",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 var path = require('path'),
     express = require('express'),
+    presenters = require(__dirname + '/app/presenters.js'),
+    defaults = require(__dirname + '/app/defaults.js'),
     routes = require(__dirname + '/app/routes.js'),
+    merge = require('merge'),
+    user_data = require(__dirname + '/lib/user_data.js'),
     app = express(),
     port = (process.env.PORT || 3000),
 
@@ -30,7 +34,7 @@ app.use('/public', express.static(__dirname + '/public'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets'));
 app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit'));
 
-app.use(express.favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico'))); 
+app.use(express.favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico')));
 
 
 // send assetPath to all views
@@ -39,6 +43,11 @@ app.use(function (req, res, next) {
   next();
 });
 
+
+// Set up the form cookie.
+app.use(express.urlencoded());
+app.use(express.cookieParser());
+app.use(user_data.form_to_cookie(presenters));
 
 // routes (found in app/routes.js)
 
@@ -50,7 +59,7 @@ app.get(/^\/([^.]+)$/, function (req, res) {
 
 	var path = (req.params[0]);
 
-	res.render(path, function(err, html) {
+	res.render(path, merge(true, defaults, req.cookies), function(err, html) {
 		if (err) {
 			console.log(err);
 			res.send(404);
@@ -59,6 +68,11 @@ app.get(/^\/([^.]+)$/, function (req, res) {
 		}
 	});
 
+});
+
+app.post(/^\/([^.]+)$/, function (req, res) {
+	var path = (req.params[0]);
+  res.redirect(path);
 });
 
 // start the app


### PR DESCRIPTION
Stores form values posted to the app as cookies, making the
values in the cookies available in templates that are rendered by the
catch-all get block in `server.js`.

Any default values that should be used if data is missing
or blank can be provided in `app/defaults.js` and any changes to the
rendering can be added to `app/presenters.js`.