### PR TITLE
Set grunt options to output Sass source maps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,13 +7,13 @@ module.exports = function(grunt){
     sass: {
       dev: {
         options: {
-          style: "expanded",
-          sourcemap: true,
           includePaths: [
             'govuk_modules/govuk_template/assets/stylesheets',
             'govuk_modules/govuk_frontend_toolkit/stylesheets'
           ],
-          outputStyle: 'expanded'
+          outputStyle: 'expanded',
+          sourceComments: true,
+          sourceMap: true
         },
         files: [{
           expand: true,

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "hogan.js": "3.0.2",
     "govuk_frontend_toolkit": "~3.1.0",
     "govuk_template_mustache": "~0.12.0",
-    "node-sass": "2.1.1",
+    "node-sass": "3.1.2",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.5.0",
     "grunt-contrib-copy": "0.5.0",
     "grunt-contrib-watch": "0.5.3",
     "grunt-nodemon": "0.3.0",
-    "grunt-sass": "0.18.0",
+    "grunt-sass": "1.0.0",
     "grunt-text-replace": "0.3.12",
     "grunt-concurrent": "0.4.3"
   }


### PR DESCRIPTION
Source maps allow the user to view and edit the Sass source files [in browser](https://developer.chrome.com/devtools/docs/css-preprocessors).

* `style` is the same as `outputStyle` so was removed
* `sourceComments` adds debug info to the output

[These instructions](http://www.sitepoint.com/using-source-maps-debug-sass-chrome/) are easier to follow than the Google documentation.