### PR TITLE
Bump govuk template to 0.13.0

### DIFF
--- a/app/views/examples/template-partial-areas.html
+++ b/app/views/examples/template-partial-areas.html
@@ -4,6 +4,14 @@
   {{>includes/examples_head}}
 {{/head}}
 
+{{$homepageUrl}}
+  https://www.gov.uk.com
+{{/homepageUrl}}
+
+{{$globalHeaderText}}
+  GOV.UK
+{{/globalHeaderText}}
+
 {{$headerClass}}with-proposition{{/headerClass}}
 
 {{$propositionHeader}}

--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -10,6 +10,8 @@ module.exports = {
   head: "{{$head}}{{/head}}",
   headerClass: "{{$headerClass}}{{/headerClass}}",
   insideHeader: "{{$insideHeader}}{{/insideHeader}}",
+  homepageUrl: "{{$homepageUrl}}https://www.gov.uk{{/homepageUrl}}",
+  globalHeaderText: "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
   pageTitle: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
   propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}"
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minimist": "0.0.8",
     "hogan.js": "3.0.2",
     "govuk_frontend_toolkit": "~4.0.1",
-    "govuk_template_mustache": "~0.12.0",
+    "govuk_template_mustache": "~0.13.0",
     "node-sass": "2.1.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
# 0.13.0

- Add `homepage_url` for overriding the href for the header logo link
("https://www.gov.uk" by default)

- Add `global_header_text` for overriding the header logo text
("GOV.UK" by default)

Here is the PR on the govuk template for context: https://github.com/alphagov/govuk_template/pull/148 

- Removed deprecated grid layout mixins:
alphagov/govuk_template#129