### PR TITLE
Update govuk template mustache to 0.15.1

### DIFF
--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -5,13 +5,17 @@ module.exports = {
   bodyEnd: "{{$bodyEnd}}{{/bodyEnd}}",
   content: "{{$content}}{{/content}}",
   cookieMessage: "{{$cookieMessage}}{{/cookieMessage}}",
+  crownCopyrightMessage: "{{$crownCopyrightMessage}}© Crown copyright{{/crownCopyrightMessage}}",
   footerSupportLinks: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
   footerTop: "{{$footerTop}}{{/footerTop}}",
+  globalHeaderText: "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
   head: "{{$head}}{{/head}}",
   headerClass: "{{$headerClass}}{{/headerClass}}",
-  insideHeader: "{{$insideHeader}}{{/insideHeader}}",
   homepageUrl: "{{$homepageUrl}}https://www.gov.uk{{/homepageUrl}}",
-  globalHeaderText: "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
+  insideHeader: "{{$insideHeader}}{{/insideHeader}}",
+  licenceMessage: "{{$licenceMessage}}<p>All content is available under the <a href='https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/' rel='license'>Open Government Licence v3.0</a>, except where otherwise stated</p>{{/licenceMessage}}",
+  logoLinkTitle: "{{$logoLinkTitle}}Go to the GOV.UK homepage{{/logoLinkTitle}}",
   pageTitle: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
-  propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}"
+  propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}",
+  skipLinkMessage: "{{$skipLinkMessage}}Skip to main content{{/skipLinkMessage}}"
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minimist": "0.0.8",
     "hogan.js": "3.0.2",
     "govuk_frontend_toolkit": "~4.0.1",
-    "govuk_template_mustache": "~0.13.0",
+    "govuk_template_mustache": "^0.15.1",
     "node-sass": "2.1.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
Update [the {{ mustache }} version of the govuk template](https://github.com/alphagov/govuk_template_mustache) from 0.13.0 to 0.15.0, this includes the following changes: 

# 0.15.1

- Fix copyright logo in Ruby version

# 0.15.0

- Add print specific logo styles

# 0.14.3

- Fix jumping logo on hover

# 0.14.2

- Drop Windows Safari font printing workaround as the font is no longer
used in print
- Update the logo to print black-on-white instead of white-on-black

# 0.14.1

- Stop copyright entity being escaped in Jinja template

# 0.14.0

- Update Crown Copyright link to new URL
- Update the font-files and move woffs into CSS
- All user-visible text in the template can now be overridden. Some
template languages which don't support default values (such as plain
mustache) will therefore lose that text and require you to handle
supplying the default.


Also supply default values for user-visible text in the template, which was introduced in # 0.14.0.