### PR TITLE
Update govuk frontend toolkit to 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "readdir": "0.0.6",
     "minimist": "0.0.8",
     "hogan.js": "3.0.2",
-    "govuk_frontend_toolkit": "~4.0.1",
+    "govuk_frontend_toolkit": "^4.2.1",
     "govuk_template_mustache": "~0.13.0",
     "node-sass": "2.1.1",
     "grunt": "0.4.5",


### PR DESCRIPTION
# 4.2.1

- Track download links using events not pageviews

# 4.2.0

- Add two analytics plugins for download and external link tracking
- Update typography mixins to be mobile first (PR #157)

# 4.1.1

- Update Accessible Media Player to remove dependency on $.browser (PR
#206)

# 4.1.0

- Add support for sending the `page` option to
`GOVUK.analytics.trackEvent` (PR #203)