### PR TITLE
Update govuk elements scss files

### DIFF
--- a/app/assets/sass/elements.scss
+++ b/app/assets/sass/elements.scss
@@ -1,15 +1,3 @@
-// includes node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit/stylesheets
-
-// Import GOV.UK frontend toolkit
-@import "colours";
-@import "measurements";
-@import "conditionals";
-@import "shims";
-@import "typography";
-@import "css3";
-@import "design-patterns/alpha-beta";
-@import "design-patterns/buttons";
-
 // Helpers
 @import "elements/helpers";
 
@@ -17,10 +5,13 @@
 @import "elements/reset";
 
 // Typography
-@import "elements/typography";
+@import "elements/elements-typography";
 
 // Layout
 @import "elements/layout";
+
+// Breadcrumb
+@import "elements/breadcrumb";
 
 // Modules
 // ==========================================================================

--- a/app/assets/sass/elements/_breadcrumb.scss
+++ b/app/assets/sass/elements/_breadcrumb.scss
@@ -1,0 +1,50 @@
+// Global breadcrumb from Alphagov - static
+// https://github.com/alphagov/static/blob/da8aeeaa749093eab30286d7fc9f965533b66f47/app/assets/stylesheets/helpers/_header.scss#L224
+// Modified to use the new grid layout mixins
+
+#global-breadcrumb {
+
+  @extend %grid-row;
+
+  ol {
+
+    @include grid-column(1);
+    padding-top: 0.75em;
+    padding-bottom: 0.75em;
+
+    li {
+
+      @include core-16;
+      float: left;
+
+      background-image: file-url("separator.png");
+      @include device-pixel-ratio() {
+        background-image: file-url("separator-2x.png");
+        background-size: 6px 11px;
+      }
+
+      background-position: 100% 50%;
+      background-repeat: no-repeat;
+
+      list-style: none;
+
+      margin-right: 0.5em;
+      margin-bottom: 0.4em;
+      margin-left: 0;
+      padding-right: 1em;
+
+      a {
+        color: $text-colour;
+      }
+
+      strong {
+        font-weight: normal;
+      }
+
+      &:last-child {
+        background-image: none;
+        margin-right: 0
+      }
+    }
+  }
+}

--- a/app/assets/sass/elements/_buttons.scss
+++ b/app/assets/sass/elements/_buttons.scss
@@ -1,5 +1,9 @@
 // Buttons
 // ==========================================================================
+// GOV.UK front end toolkit dependencies
+@import "design-patterns/buttons";
+@import "measurements";
+@import "typography";
 
 .button {
   @include button ($button-colour);
@@ -19,7 +23,7 @@
 }
 
 .button:focus {
-  outline: 3px solid $yellow;
+  outline: 3px solid $focus-colour;
 }
 
 // Disabled buttons
@@ -32,6 +36,7 @@
 }
 
 // Start now buttons
+.button-start,
 .button-get-started {
   @include bold-24;
   background-image: file-url("icons/icon-pointer.png");

--- a/app/assets/sass/elements/_details.scss
+++ b/app/assets/sass/elements/_details.scss
@@ -1,38 +1,40 @@
 // Details
 // ==========================================================================
+// GOV.UK front end toolkit dependencies
+@import "colours";
 
 details {
   display: block;
-}
 
-details summary {
-  display: inline-block;
-  color: $govuk-blue;
-  cursor: pointer;
-  position: relative;
-  margin-bottom: em(5);
-}
+  summary {
+    display: inline-block;
+    color: $govuk-blue;
+    cursor: pointer;
+    position: relative;
+    margin-bottom: em(5);
 
-details summary:hover {
-  color: $link-hover-colour;
-}
+    &:hover {
+      color: $link-hover-colour;
+    }
 
-details summary:focus {
-  outline: 3px solid $yellow;
-}
-
-// Underline only summary text (not the arrow)
-details .summary {
-  text-decoration: underline;
-}
-
-// Match fallback arrow spacing with -webkit default
-details .arrow {
-  margin-right: 0.35em;
-  font-style: normal;
-}
-
-// Remove top margin from bordered panel
-details .panel-indent {
-  margin-top: 0;
+    &:focus {
+      outline: 3px solid $focus-colour;
+    }
+  }
+  
+  // Underline only summary text (not the arrow)
+  .summary {
+    text-decoration: underline;
+  }
+  
+  // Match fallback arrow spacing with -webkit default
+  .arrow {
+    margin-right: .35em;
+    font-style: normal;
+  }
+  
+  // Remove top margin from bordered panel
+  .panel-indent {
+    margin-top: 0;
+  }
 }

--- a/app/assets/sass/elements/_elements-typography.scss
+++ b/app/assets/sass/elements/_elements-typography.scss
@@ -1,6 +1,10 @@
 // Typography
 // ==========================================================================
 
+// GOV.UK front end toolkit dependencies
+@import "typography";
+@import "colours";
+
 // Increase the base font size to 19px for the main content area
 // Using the core-19 mixin from the govuk_toolkit _typography.scss file
 
@@ -13,18 +17,23 @@ main {
 .font-xxlarge {
   @include core-80;
 }
+
 .font-xlarge {
   @include core-48;
 }
+
 .font-large {
   @include core-36;
 }
+
 .font-medium {
   @include core-24;
 }
+
 .font-small {
   @include core-19;
 }
+
 .font-xsmall {
   @include core-16;
 }
@@ -33,18 +42,23 @@ main {
 .bold-xxlarge {
   @include bold-80();
 }
+
 .bold-xlarge {
   @include bold-48();
 }
+
 .bold-large {
   @include bold-36();
 }
+
 .bold-medium {
   @include bold-24();
 }
+
 .bold-small {
   @include bold-19();
 }
+
 .bold-xsmall {
   @include bold-16();
 }
@@ -81,7 +95,7 @@ main {
   margin-bottom: em(10, 24);
 
   @include media(tablet) {
-    margin-top: em(45, 36 );
+    margin-top: em(45, 36);
     margin-bottom: em(20, 36);
   }
 
@@ -121,7 +135,7 @@ main {
 
 // Text
 p {
-  margin-top: em(5, 16 );
+  margin-top: em(5, 16);
   margin-bottom: em(20, 16);
 
   @include media(tablet) {
@@ -151,25 +165,116 @@ p {
   color: $link-colour;
   text-decoration: underline;
 }
+
 .link:visited {
   color: $link-visited-colour;
 }
+
 .link:hover {
   color: $link-hover-colour;
 }
+
 .link:active {
   color: $link-colour;
 }
 
+// Back link styles - with left pointing arrow
+
+.link-back {
+  @include inline-block;
+  position: relative;
+
+  @include core-16;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+  padding-left: 14px;
+
+  color: $black;
+
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    color: $black;
+  }
+
+  text-decoration: none;
+  border-bottom: 1px solid $black;
+
+  // Back arrow - left pointing black arrow
+  &::before {
+    content: '';
+    display: block;
+    width: 0;
+    height: 0;
+
+    border-top: 5px solid transparent;
+    border-right: 6px solid #0b0c0c;
+    border-bottom: 5px solid transparent;
+
+    position: absolute;
+    left: 0;
+    top: 50%;
+    margin-top: -6px;
+  }
+
+  // Improve arrow shape in Firefox
+  @-moz-document url-prefix() {
+    &::before {
+      border-top: 5px dotted rgba(255, 0, 0, 0);
+      border-bottom: 5px dotted rgba(255, 0, 0, 0);
+    }
+  }
+
+  // Fallback
+  // IE8 doesn't support rgba and only supports the single colon syntax for :before
+  // IE7 doesn't support pseudo-elements, let's fallback to an image instead.
+  // Ref: http://caniuse.com/#search=%3Abefore, http://caniuse.com/#search=rgba
+  @include ie-lte(8) {
+   background: file-url("icon-arrow-left.png") no-repeat 0 4px;
+  }
+
+}
+
 // Code styles
-pre,
-code {
-  font-size: 13px;
-  line-height: 19px;
+.code {
+  color: black;
+  text-shadow: 0 1px white;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 14px;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+
   color: $black;
   background-color: $highlight-colour;
   border: 1px solid $border-colour;
-  padding: 3px 7px;
+  padding: 4px 4px 2px 4px;
 }
 
-
+// Horizontal rule style
+hr {
+  display: block;
+  background: $border-colour;
+  border: 0;
+  height: 1px;
+  margin-top: $gutter;
+  margin-bottom: $gutter;
+  padding: 0;
+  @include ie-lte(7) {
+    color: $border-colour;
+  }
+}

--- a/app/assets/sass/elements/_forms.scss
+++ b/app/assets/sass/elements/_forms.scss
@@ -1,46 +1,99 @@
 // Forms
 // ==========================================================================
 
+// Contents:
+//
+// 1. GOV.UK front end toolkit dependencies
+// 2. Helpers
+// 3. Form wrappers
+// 4. Form labels
+// 5. Form hints
+// 6. Form controls
+// 7. Form control widths
+
+// 8. Errors and validation styles
+// 9. Form design patterns
+//     - Date of birth
+//     - "Chunky" radio buttons and checkboxes
+
+
+// 1. GOV.UK front end toolkit dependencies
+// ==========================================================================
+
+@import "helpers";
+@import "colours";
+
+
+// 2. Helpers
+// ==========================================================================
+
 // Fieldset is used to group more than one .form-group
 fieldset {
-  width: 100%;
   @extend %contain-floats;
+  width: 100%;
 }
+
+// Fix left hand gap in IE7 and below
+@include ie-lte(7) {
+  legend {
+    margin-left: -7px;
+  }
+}
+
+// Remove margin under textarea in Chrome and FF
+textarea{
+  display: block;
+}
+
+
+// 3. Form wrappers
+// ==========================================================================
 
 // Form group is used to wrap label and input pairs
 .form-group {
+  @extend %contain-floats;
+  @include box-sizing(border-box);
+
   float: left;
   width: 100%;
-  @extend %contain-floats;
+
   margin-bottom: $gutter-half;
+
   @include media(tablet) {
     margin-bottom: $gutter;
   }
 }
 
+// Form group related is used to reduce the space between label and input pairs
 .form-group-related {
   margin-bottom: 10px;
+
   @include media(tablet) {
     margin-bottom: 20px;
   }
 }
 
+// Form group compound is used to reduce the space between label and input pairs
 .form-group-compound {
   margin-bottom: 10px;
 }
 
 // Form title
+// TODO: Remove this (duplication of existing heading styles)
 .form-title {
   margin-bottom: $gutter;
+
   @include media(tablet) {
     margin-bottom: ($gutter*1.5);
   }
 }
 
 
-// Labels
+// 4. Form labels
+// ==========================================================================
 
 // Form labels, or for legends styled to look like labels
+// TODO: Amend so there is only one label style
 .form-label,
 .form-label-bold {
   display: block;
@@ -49,111 +102,163 @@ fieldset {
 
 .form-label {
   @include core-19;
-  margin-bottom: 5px;
 }
 
 .form-label-bold {
-  @include bold-24;
-  margin-bottom: 0;
-  .form-hint {
-    @include core-19;
+  @include bold-19;
+}
+
+// Add spacing under spans within labels
+legend {
+  .form-label,
+  .form-label-bold {
+    padding-bottom: 7px;
+  }
+}
+
+// Remove spacing when error messages are shown
+// TODO: Move into /forms/_form-validation.scss
+.error legend {
+  .form-label,
+  .form-label-bold {
+    padding-bottom: 0;
   }
 }
 
 // Used for paragraphs in-between form elements
 .form-block {
+  @extend %contain-floats;
   float: left;
   width: 100%;
-  @extend %contain-floats;
-}
 
-
-// Hints
-
-// Form hints & examples are light grey and sit above a form control
-.form-hint {
-  display: block;
-  color: $secondary-text-colour;
   margin-bottom: 5px;
-  @include media (tablet) {
-    margin-top: 8px;
+
+  @include media(tablet) {
+    margin-top: 10px;
   }
 }
 
+// 5. Form hints
+// ==========================================================================
 
-// Form controls
+// Form hints and example text are light grey and sit above a form control
+.form-hint {
+  @include core-19;
+  display: block;
+  color: $secondary-text-colour;
+  font-weight: normal;
+  margin-bottom: 5px;
+}
+
+
+// 6. Form controls
+// ==========================================================================
 
 // By default, form controls are 50% width for desktop,
 // and 100% width for mobile
 .form-control {
-  @include core-19;
-
-  width: 100%;
   @include box-sizing(border-box);
+  @include core-19;
+  width: 100%;
+
   padding: 4px;
   background-color: $white;
   border: 1px solid $border-colour;
 
-  // Disable webkit appearance and remove rounded corners
-  -webkit-appearance: none;
-  border-radius: 0;
-
+  // TODO: Remove 50% width set for tablet and up
+  // !! BREAKING CHANGE !!
   @include media(tablet) {
     width: 50%;
   }
+
 }
-
-
-// Form control widths
-.form-control-3-4 {
-  width: 100%;
-  @include media(tablet) {
-    width: 75%;
-  }
-}
-
-.form-control-1-2 {
-  width: 100%;
-  @include media(tablet) {
-    width: 50%;
-  }
-}
-
-.form-control-1-4 {
-  width: 25%;
-}
-
-.form-control-1-8 {
-  width: 12.5%;
-}
-
 
 // Radio buttons
 .form-radio {
   display: block;
   margin: 10px 0;
-}
-.form-radio input {
-  vertical-align: middle;
-  margin: -4px 5px 0 0;
-}
 
+  input {
+    vertical-align: middle;
+    margin: -4px 5px 0 0;
+  }
+}
 
 // Checkboxes
 .form-checkbox {
   display: block;
   margin: $gutter-half 0;
-}
-.form-checkbox input {
-  vertical-align: middle;
-  margin: -2px 5px 0 0;
+
+  input {
+    vertical-align: middle;
+    margin: -2px 5px 0 0;
+  }
 }
 
 
-// Form validation
+// 7. Form control widths
+// ==========================================================================
+
+// TODO: Update these
+// Form control widths
+
+.form-control-3-4 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 75%;
+  }
+}
+
+.form-control-2-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 66.66%;
+  }
+}
+
+.form-control-1-2 {
+  width: 100%;
+
+  @include media(tablet) {
+    width: 50%;
+  }
+}
+
+.form-control-1-3 {
+  width: 100%;
+  @include media(tablet) {
+    width: 33.33%;
+  }
+}
+
+.form-control-1-4 {
+  width: 100%;
+  @include media(tablet) {
+    width: 25%;
+  }
+}
+
+.form-control-1-8 {
+  width: 100%;
+  @include media(tablet) {
+    width: 12.5%;
+  }
+}
+
+
+// 8. Errors and validation styles
+// ==========================================================================
 @import "forms/form-validation";
 
 
-// Form patterns
+// 9. Form design patterns
+//    - Date of birth
+//    - "Chunky" radio buttons and checkboxes
+// ==========================================================================
+
+// Date of birth
 @import "forms/form-date";
+
+// "Chunky" radios and checkboxes
 @import "forms/form-block-labels";

--- a/app/assets/sass/elements/_helpers.scss
+++ b/app/assets/sass/elements/_helpers.scss
@@ -1,5 +1,17 @@
 // Helpers
 // ==========================================================================
+// GOV.UK front end toolkit dependencies
+@import "colours";
+@import "shims";
+@import "measurements";
+@import "typography";
+@import "css3";
+@import "url-helpers";
+
+// Path to assets for use with file-url() is not already defined
+@if ($path == false) {
+  $path: "/public/images/";
+}
 
 // Return ems from a pixel value
 // This assumes a base of 19px
@@ -11,18 +23,14 @@
 // add this class to the body to see how grid padding is set
 .example-highlight-grid {
   .grid-row {
-    background:  $grey-2;
+    background: $grey-2;
   }
+
   .column-highlight {
     background: $grey-3;
     width: 100%;
   }
-}
 
-// Used to space the "back" link on example pages
-.example-back-link {
-  @include inline-block;
-  margin-top: $gutter;
 }
 
 // Hide, but not for screenreaders
@@ -30,8 +38,11 @@
   position: absolute;
   overflow: hidden;
   clip: rect(0 0 0 0);
-  height: 1px; width: 1px;
-  margin: -1px; padding: 0; border: 0;
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }
 
 // Hide, only when JavaScript is enabled

--- a/app/assets/sass/elements/_icons.scss
+++ b/app/assets/sass/elements/_icons.scss
@@ -1,4 +1,6 @@
 // GOV.UK icons
+// GOV.UK front end toolkit dependencies
+@import "device-pixels";
 
 .icon {
   background-position: 0 0;
@@ -6,85 +8,94 @@
 }
 
 .icon-calendar {
+  width: 27px;
+  height: 27px;
   background-image: file-url("icons/icon-calendar.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-calendar-2x.png");
     background-size: 100%;
   }
-  width: 27px;
-  height: 27px;
 }
 
 .icon-download {
+  width: 30px;
+  height: 39px;
   background-image: file-url("icons/icon-file-download.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-file-download-2x.png");
     background-size: 100%;
-  }
-  width: 30px;
-  height: 39px;
+  } 
 }
 
 .icon-important {
+  width: 34px;
+  height: 34px;
   background-image: file-url("icons/icon-important.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-important-2x.png");
     background-size: 100%;
   }
-  width: 34px;
-  height: 34px;
 }
 
 .icon-information {
+  width: 27px;
+  height: 27px;
   background-image: file-url("icons/icon-information.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-information-2x.png");
     background-size: 100%;
   }
-  width: 27px;
-  height: 27px;
 }
 
 .icon-locator {
+  width: 26px;
+  height: 36px;
   background-image: file-url("icons/icon-locator.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-locator-2x.png");
     background-size: 100%;
   }
-  width: 26px;
-  height: 36px;
 }
 
 .icon-search {
+  width: 30px;
+  height: 22px;
+  background-color: $black;
   background-image: file-url("icons/icon-search.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-search-2x.png");
     background-size: 100%;
   }
-  width: 30px;
-  height: 22px;
-  background-color: black;
 }
 
 // GOV.UK arrow icons
 .icon-pointer {
+  width: 30px;
+  height: 19px;
+  background-color: $black;
   background-image: file-url("icons/icon-pointer.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-pointer-2x.png");
     background-size: 100%;
   }
-  width: 30px;
-  height: 19px;
-  background-color: black;
 }
+
 .icon-pointer-black {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-pointer-black.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-pointer-black-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 // GOV.UK external link icons
@@ -92,131 +103,144 @@
 
 // GOV.UK step icons
 .icon-step-1 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-1.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-1-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-2 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-2.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-2-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-3 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-3.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-3-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-4 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-4.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-4-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-5 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-5.png");
+  
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-5-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-6 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-6.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-6-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-7 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-7.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-7-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-8 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-8.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-8-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-9 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-9.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-9-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-10 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-10.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-10-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-11 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-11.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-11-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-12 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-12.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-12-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }
 
 .icon-step-13 {
+  width: 23px;
+  height: 23px;
   background-image: file-url("icons/icon-steps/icon-step-13.png");
+
   @include device-pixel-ratio() {
     background-image: file-url("icons/icon-steps/icon-step-13-2x.png");
     background-size: 100%;
   }
-  width: 23px;
-  height: 23px;
 }

--- a/app/assets/sass/elements/_layout.scss
+++ b/app/assets/sass/elements/_layout.scss
@@ -1,13 +1,23 @@
 // Layout
 // ==========================================================================
 
+// GOV.UK front end toolkit dependencies
+@import "measurements";
+@import "conditionals";
+@import "grid_layout";
+@import "helpers";
+@import "design-patterns/alpha-beta";
+
+
 // Content
 // ==========================================================================
 
+// Content wraps the entire site content block
 #content {
   @extend %site-width-container;
   @extend %contain-floats;
   padding-bottom: $gutter;
+  
   @include media(desktop) {
     padding-bottom: $gutter*3;
   }
@@ -17,7 +27,7 @@
 // Phase banner
 // ==========================================================================
 
-.phase-banner  {
+.phase-banner {
   @include phase-banner(alpha);
 }
 
@@ -45,14 +55,17 @@
 // Use .grid-column to create a grid column with 15px gutter
 // By default grid columns break to become full width at tablet size
 .column-quarter {
-  @include grid-column( 1/4 );
+  @include grid-column(1/4);
 }
+
 .column-half {
-  @include grid-column( 1/2 );
+  @include grid-column(1/2);
 }
+
 .column-third {
-  @include grid-column( 1/3 );
+  @include grid-column(1/3);
 }
+
 .column-two-thirds {
-  @include grid-column( 2/3 );
+  @include grid-column(2/3);
 }

--- a/app/assets/sass/elements/_lists.scss
+++ b/app/assets/sass/elements/_lists.scss
@@ -17,6 +17,7 @@ ol {
 .list-number {
   list-style-type: decimal;
   padding-left: 20px;
+  
   @include ie-lte(7) {
     padding-left: 28px;
   }

--- a/app/assets/sass/elements/_panels.scss
+++ b/app/assets/sass/elements/_panels.scss
@@ -1,5 +1,8 @@
 // Panels
 // ==========================================================================
+// GOV.UK front end toolkit dependencies
+@import "helpers";
+
 
 // Indented panels with a grey left hand border
 .panel-indent {
@@ -9,18 +12,18 @@
 
   padding: 10px 0 10px $gutter-half;
   margin: ($gutter $gutter-half $gutter*1.5 0);
-}
 
-.panel-indent legend {
-  margin-top: 0;
-}
-
-// Remove bottom margin on last paragraph
-.panel-indent p:only-child,
-.panel-indent p:last-child {
-  margin-bottom: 0;
-}
-
-.panel-indent .form-group:last-child {
-  margin-bottom: 0;
+  legend {
+    margin-top: 0;
+  }
+  
+  // Remove bottom margin on last paragraph
+  p:only-child,
+  p:last-child {
+    margin-bottom: 0;
+  }
+  
+  .form-group:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/app/assets/sass/elements/_tables.scss
+++ b/app/assets/sass/elements/_tables.scss
@@ -1,33 +1,36 @@
 // Tables
 // ==========================================================================
+// GOV.UK front end toolkit dependencies
+@import "typography";
+@import "colours";
+
 
 table {
   border-collapse: collapse;
   border-spacing: 0;
   width: 100%;
-}
 
-table th,
-table td {
-  @include core-16;
-  padding: em(12, 16) em(20, 16) em(9, 16) 0;
+  th,
+  td {
+    @include core-16;
+    padding: em(12, 16) em(20, 16) em(9, 16) 0;
 
-  text-align: left;
-  color: #0b0c0c;
-  border-bottom: 1px solid $border-colour;
-}
+    text-align: left;
+    color: $black;
+    border-bottom: 1px solid $border-colour;
+  }
 
-table th {
-  font-weight: 700;
-}
+  th {
+    font-weight: 700;
+    // Right align headings for numeric content
+    &.numeric {
+      text-align: right;
+    } 
+  }
 
-// Right align headings for numeric content
-table th.numeric {
-  text-align: right;
-}
-
-// Use tabular numbers for numeric table cells
-table td.numeric {
-  @include core-16($tabular-numbers: true);
-  text-align: right;
+  // Use tabular numbers for numeric table cells
+  td.numeric {
+    @include core-16($tabular-numbers: true);
+    text-align: right;
+  }
 }

--- a/app/assets/sass/elements/forms/_form-block-labels.scss
+++ b/app/assets/sass/elements/forms/_form-block-labels.scss
@@ -5,6 +5,7 @@
 @import "measurements";
 @import "conditionals";
 
+
 // By default, block labels stack vertically
 .block-label {
 
@@ -15,25 +16,28 @@
 
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
+  padding: (18px $gutter $gutter-half $gutter*1.8);
 
+  margin-bottom: 10px;
   cursor: pointer; // Encourage clicking on block labels
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
     // width: 25%; - Test : check that text within labels will wrap
   }
 
   // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 18px;
+    top: 15px;
     left: $gutter-half;
     cursor: pointer;
+    margin: 0;
+    width: 29px;
+    height: 29px;
+    @include ie(8) {
+      top: 12px;
+    }
   }
 
   // Change border on hover
@@ -42,10 +46,14 @@
   }
 }
 
+.block-label:last-child {
+  margin-bottom: 0;
+}
+
 // To stack horizontally, use .inline on parent, to sit block labels next to each other
 .inline .block-label {
   clear: none;
-  margin-right: $gutter-half;
+  margin-right: 10px;
 }
 
 // Selected and focused states
@@ -58,7 +66,7 @@
 
 // Add focus to block labels
 .js-enabled label.focused {
-  outline: 3px solid $yellow;
+  outline: 3px solid $focus-colour;
 }
 
 // Remove focus from radio/checkboxes

--- a/app/assets/sass/elements/forms/_form-date.scss
+++ b/app/assets/sass/elements/forms/_form-date.scss
@@ -5,10 +5,11 @@
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
-  margin: 0
+  margin: 0;
 }
+
 input[type=number] {
-  -moz-appearance: textfield
+  -moz-appearance: textfield;
 }
 
 .form-date {
@@ -29,11 +30,9 @@ input[type=number] {
     input {
       width: 100%;
     }
-
   }
 
   .form-group-year {
     width: 70px;
   }
-
 }

--- a/app/assets/sass/elements/forms/_form-validation.scss
+++ b/app/assets/sass/elements/forms/_form-validation.scss
@@ -1,63 +1,104 @@
-// Validation summary box
+// Form validation
+// ==========================================================================
 
-.validation-summary {
-  border: 3px solid $error-colour;
-  padding: $gutter-half $gutter;
-  margin-bottom: $gutter;
+// Using the classname .error as it's shorter than .validation and easier to type!
+.error {
 
-  @include ie-lte(6){
+  // Ensure the .error class is applied to .form-group, otherwide box-sizing(border-box) will need to be used
+  // @include box-sizing(border-box);
+  margin-right: 15px;
+
+  // Error messages should be red and bold
+  .error-message {
+    color: $error-colour;
+    font-weight: bold;
+  }
+
+  // Form inputs should have a red border
+  .form-control {
+    border: 4px solid $error-colour;
+  }
+
+  .form-hint {
+    margin-bottom: 0;
+  }
+
+}
+
+.error,
+.error-summary {
+
+  // Add a red border to the left of the field
+  border-left: 4px solid $error-colour;
+  padding-left: 10px;
+
+  @include media(tablet) {
+    border-left: 5px solid $error-colour;
+    padding-left: $gutter-half;
+  }
+}
+
+.error-message {
+  @include core-19;
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 5px 0 7px 0;
+}
+
+// Summary of multiple error messages
+.error-summary {
+
+  // Error summary has a border on all sides
+  border: 4px solid $error-colour;
+
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
+
+  padding: $gutter-half 10px;
+
+  @include media(tablet) {
+    border: 5px solid $error-colour;
+
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+
+    padding: 20px $gutter-half $gutter-half $gutter-half;
+  }
+
+  @include ie-lte(6) {
     zoom: 1;
   }
-}
 
-.validation-summary ul {
-  margin-top: 10px;
-}
-
-.validation-summary li,
-.validation-summary p {
-  @include core-16;
-}
-
-.validation-summary p {
-  margin-top: $gutter-half;
-  margin-bottom: 5px;
-}
-
-.validation-summary a {
-  color: $error-colour;
-  @include ie-lte(6) {
-    color: $error-colour !important;
+  // Use the GOV.UK outline focus style
+  &:focus {
+    outline: 3px solid $focus-colour;
   }
-}
 
-.validation-summary .heading-small {
-  margin-top: $gutter-half;
-}
+  .error-summary-heading {
+    margin-top: 0;
+  }
 
+  p {
+    margin-bottom: 10px;
+  }
 
-// Validation error message box
-// .validation-error {
-//   clear: both;
-//   @extend %contain-floats;
-//   border-left: 3px solid $error-colour;
-//   padding: $gutter- $gutter;
-//   margin-bottom: $gutter-half;
-//   margin-left: -($gutter);
-// }
+  .error-summary-list {
+    padding-left: 0;
 
-// .validation-error .form-group {
-//   margin-bottom: 20px;
-// }
+    li {
 
-// .validation-error p {
-//   margin-bottom: 10px;
-// }
+      @include media(tablet) {
+        margin-bottom: 5px;
+      }
+    }
 
-
-// Validation message
-.validation-message {
-  display: block;
-  @include core-16;
-  color: $error-colour;
+    a {
+      color: $error-colour;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
 }

--- a/app/views/examples/elements/forms.html
+++ b/app/views/examples/elements/forms.html
@@ -7,7 +7,7 @@
 {{$content}}
 <main id="content" role="main">
 
-  <a href="/examples/" class="example-back-link">Back to the GOV.UK prototype kit examples</a>
+  <a class="link-back" href="/examples/">Back to the GOV.UK prototype kit examples</a>
 
   <form action="/" method="post" class="form">
 

--- a/app/views/examples/elements/grid-layout.html
+++ b/app/views/examples/elements/grid-layout.html
@@ -7,7 +7,7 @@
 {{$content}}
 <main id="content" role="main">
 
-  <a href="/examples/" class="example-back-link">Back to the GOV.UK prototype kit examples</a>
+  <a class="link-back" href="/examples/">Back to the GOV.UK prototype kit examples</a>
 
   <h1 class="heading-xlarge">
     New grid layout example

--- a/app/views/examples/elements/typography.html
+++ b/app/views/examples/elements/typography.html
@@ -7,7 +7,7 @@
 {{$content}}
 <main id="content" role="main">
 
-  <a href="/examples/" class="example-back-link">Back to the GOV.UK prototype kit examples</a>
+  <a class="link-back" href="/examples/">Back to the GOV.UK prototype kit examples</a>
 
   <h1 class="heading-xlarge">
     Typography


### PR DESCRIPTION
To make this easier to keep up-to-date in the future - update each partial to match those here:
https://github.com/alphagov/govuk_elements/tree/master/public/sass/elements

This moves @import statements for any GOV.UK front end toolkit dependencies from the top of the elements.scss file to the top of each partial.

The main changes here are:
- addition of breadcrumb partial
- use of $focus-colour variable
- error message styles
- numeric tabular data styles
- larger radio button and checkbox inputs

Back links are also renamed.