### PR TITLE
Add sublime project file - ignore public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 public
 govuk_modules
 node_modules/*
+*.sublime-workspace

--- a/govuk_prototype_kit.sublime-project
+++ b/govuk_prototype_kit.sublime-project
@@ -1,0 +1,12 @@
+{
+	"folders":
+	[
+		{
+			"path": ".",
+            "folder_exclude_patterns": ["public"]
+		}
+	],
+	"settings":
+	{
+	}
+}

--- a/lib/template-engine.js
+++ b/lib/template-engine.js
@@ -92,7 +92,13 @@ TemplateEngine._storeTemplate = function (basePath) {
    return function (templatePath) {
       var templateName = TemplateEngine._getTemplateName(basePath, templatePath);
 
-      TemplateEngine.__templates[templateName] = Hogan.compile(FS.readFileSync(templatePath, 'utf-8'));
+      var template = FS.readFileSync(templatePath, 'utf-8');
+
+      if (process.platform == ('win32' || 'win64')){
+         template = template.replace(/(\{\{>.*)\//g, '$1\\');
+      }
+
+      TemplateEngine.__templates[templateName] = Hogan.compile(template);
 
       if (argv.verbose){
          console.log('Stored template', templateName);


### PR DESCRIPTION
In my Sublime Text workflow, I'm often using `cmd + P` to jump to files.

This can lead to opening js and css files in `public`, which is bad because any changes get overwritten by Grunt.

This PR means Sublime ignores the `public` folder - it doesn't show in the file navigator or in the `cmd + P` search results.

I think conceptually this is correct - public should really just be a folder that gets resources saved to it by the kit. You shouldn't be editing it directly.