### PR TITLE
Hide public folder in Sublime Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 public
 govuk_modules
 node_modules/*
+*.sublime-workspace

--- a/govuk_prototype_kit.sublime-project
+++ b/govuk_prototype_kit.sublime-project
@@ -3,10 +3,7 @@
 	[
 		{
 			"path": ".",
-            "folder_exclude_patterns": ["public"]
+      "folder_exclude_patterns":["public"]
 		}
-	],
-	"settings":
-	{
-	}
+	]
 }

--- a/govuk_prototype_kit.sublime-project
+++ b/govuk_prototype_kit.sublime-project
@@ -1,0 +1,12 @@
+{
+	"folders":
+	[
+		{
+			"path": ".",
+            "folder_exclude_patterns": ["public"]
+		}
+	],
+	"settings":
+	{
+	}
+}


### PR DESCRIPTION
In my Sublime Text workflow, I'm often using cmd + P to jump to files.

This can lead to opening js and css files in public, which is bad because any changes get overwritten by Grunt.

This PR means Sublime ignores the public folder - it doesn't show in the file navigator or in the cmd + P search results.

I think conceptually this is correct - public should really just be a folder that gets resources saved to it by the kit. You shouldn't be editing it directly.