### PR TITLE
Alter process clean-up to not use pid file

### DIFF
--- a/start.js
+++ b/start.js
@@ -1,10 +1,4 @@
-var fs = require('fs'),
-    argv = require('minimist')(process.argv.slice(2)),
-    fileOptions = { encoding : 'utf-8' },
-    gruntfile;
-
-// start grunt
-gruntfile = __dirname + '/Gruntfile.js';
+var gruntfile = __dirname + '/Gruntfile.js';
 require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
   'gruntfile' : gruntfile
 });

--- a/start.js
+++ b/start.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2)),
-    pidFile = __dirname + '/.start.pid',
     fileOptions = { encoding : 'utf-8' },
     gruntfile;
 
@@ -10,12 +9,7 @@ require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
   'gruntfile' : gruntfile
 });
 
-fs.writeFileSync(pidFile, process.pid, fileOptions);
-
 process.on('SIGINT', function() {
-  var pid = fs.readFileSync(pidFile, fileOptions);
-
-  fs.unlink(pidFile);
-  process.kill(pid, 'SIGTERM');
+  process.kill(process.pid, 'SIGTERM');
   process.exit();
 });


### PR DESCRIPTION
The existing clean-up process made some flawed
assumptions which resulted in the following error
when ctrl-c was pressed:

```
Fatal error: ENOENT: no such file or directory, open '/Users/../govuk_prototype_kit/.start.pid'
```

This command spawns 3 child processes:
- a grunt watch task
- nodemon
- the `node server.js` command spawned by nodemon

The existing approach made an assumption that the
SIGINT event would only be called for the parent
process when, in fact, it was called for each
process (4 in total). The code that ran needed the
`.start.pid` file to exist so only worked the
first time, after which it had been removed.

This approach instead kills each process called by
SIGINT within the scope of that process instead of
relying on a reference external to that scope.

Note: This fix is based on an understanding of how
ctrl-c works, taken from this answer:

http://unix.stackexchange.com/questions/149741/why-is-sigint-not-propagated-to-child-process-when-sent-to-its-parent-process#answers-header