### PR TITLE
Update govuk elements

### DIFF
--- a/app/assets/sass/elements.scss
+++ b/app/assets/sass/elements.scss
@@ -33,3 +33,9 @@
 
 // Panels
 @import "elements/panels";
+
+// Components
+// ==========================================================================
+// .govuk-prefixed styles
+
+@import "elements/components";

--- a/app/assets/sass/elements/_components.scss
+++ b/app/assets/sass/elements/_components.scss
@@ -1,0 +1,9 @@
+// Box with turquoise background and white text
+// Used for transaction end pages, and Bank Holidays
+.govuk-box-highlight {
+  margin: 1em 0 1em 0;
+  padding: 2em 0 1em 0;
+  color: $white;
+  background: $turquoise;
+  text-align: center;
+}

--- a/app/assets/sass/elements/_details.scss
+++ b/app/assets/sass/elements/_details.scss
@@ -21,20 +21,16 @@ details {
       outline: 3px solid $focus-colour;
     }
   }
-  
+
   // Underline only summary text (not the arrow)
   .summary {
     text-decoration: underline;
   }
-  
+
   // Match fallback arrow spacing with -webkit default
   .arrow {
     margin-right: .35em;
     font-style: normal;
   }
-  
-  // Remove top margin from bordered panel
-  .panel-indent {
-    margin-top: 0;
-  }
+
 }

--- a/app/assets/sass/elements/_panels.scss
+++ b/app/assets/sass/elements/_panels.scss
@@ -8,22 +8,27 @@
 .panel-indent {
   @extend %contain-floats;
   clear: both;
-  border-left: 4px solid $border-colour;
+  border-left: 5px solid $border-colour;
 
-  padding: 10px 0 10px $gutter-half;
-  margin: ($gutter $gutter-half $gutter*1.5 0);
+  padding: em(15,19);
+  margin-bottom: em(15,19);
 
-  legend {
+  :first-child {
     margin-top: 0;
   }
-  
-  // Remove bottom margin on last paragraph
-  p:only-child,
-  p:last-child {
+
+  :only-child,
+  :last-child {
     margin-bottom: 0;
   }
-  
-  .form-group:last-child {
-    margin-bottom: 0;
-  }
+
+}
+
+.panel-indent-info {
+  border-left-width: 10px;
+}
+
+// Indented panels within form groups
+.form-group .panel-indent {
+  padding-bottom: 0;
 }


### PR DESCRIPTION
Adjust spacing for idented panels.

Add .govuk prefixed box styles - to be used for transaction end pages.

If this can be merged before #35, that PR can use the `.govuk-box-highlight` styles for the transaction end page.

Also, there is an example of the transaction end page here:
http://govuk-elements.herokuapp.com/colour/#examples

@rivalee, @joelanman, @timpaul.