### PR TITLE
Add instructions for running multiple local instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ node start.js
 
 Go to [localhost:3000](http://localhost:3000) in your browser.
 
+If you want to view multiple prototypes at the same time you can give them unique port numbers, like this:
+
+```
+PORT=3005 node start.js
+```
+
+To change the port number permanently, edit the port variable in /server.js. 
+
 #### Hot reload
 
 Any code changes should update in the browser without you restarting the app.


### PR DESCRIPTION
Following a discussion on the prototype-kit Slack channel, add instructions on how to run multiple instances of a prototype on your local machine.