### PR TITLE
Add selection buttons js from the front end toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,8 @@
+$(document).ready(function() {
+
+  // Use GOV.UK selection-buttons.js to set selected
+  // and focused states for block labels
+  var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']");
+  new GOVUK.SelectionButtons($blockLabels);
+
+});

--- a/app/assets/javascripts/govuk/selection-buttons.js
+++ b/app/assets/javascripts/govuk/selection-buttons.js
@@ -1,0 +1,111 @@
+(function () {
+  "use strict";
+  var root = this,
+      $ = root.jQuery;
+
+  if (typeof GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var SelectionButtons = function (elmsOrSelector, opts) {
+    var $elms;
+
+    this.selectedClass = 'selected';
+    this.focusedClass = 'focused';
+    if (opts !== undefined) {
+      $.each(opts, function (optionName, optionObj) {
+        this[optionName] = optionObj;
+      }.bind(this));
+    }
+    if (typeof elmsOrSelector === 'string') {
+      $elms = $(elmsOrSelector);
+      this.selector = elmsOrSelector;
+      this.setInitialState($(this.selector));
+    } else if (elmsOrSelector !== undefined) {
+      this.$elms = elmsOrSelector;
+      this.setInitialState(this.$elms);
+    }
+    this.addEvents();
+  };
+  SelectionButtons.prototype.addEvents = function () {
+    if (typeof this.$elms !== 'undefined') {
+      this.addElementLevelEvents();
+    } else {
+      this.addDocumentLevelEvents();
+    }
+  };
+  SelectionButtons.prototype.setInitialState = function ($elms) {
+    $elms.each(function (idx, elm) {
+      var $elm = $(elm);
+
+      if ($elm.is(':checked')) {
+        this.markSelected($elm);
+      }
+    }.bind(this));
+  };
+  SelectionButtons.prototype.markFocused = function ($elm, state) {
+    if (state === 'focused') {
+      $elm.parent('label').addClass(this.focusedClass);
+    } else {
+      $elm.parent('label').removeClass(this.focusedClass);
+    }
+  };
+  SelectionButtons.prototype.markSelected = function ($elm) {
+    var radioName;
+
+    if ($elm.attr('type') === 'radio') {
+      radioName = $elm.attr('name');
+      $($elm[0].form).find('input[name="' + radioName + '"]')
+        .parent('label')
+        .removeClass(this.selectedClass);
+      $elm.parent('label').addClass(this.selectedClass);
+    } else { // checkbox
+      if ($elm.is(':checked')) {
+        $elm.parent('label').addClass(this.selectedClass);
+      } else {
+        $elm.parent('label').removeClass(this.selectedClass);
+      }
+    }
+  };
+  SelectionButtons.prototype.addElementLevelEvents = function () {
+    this.clickHandler = this.getClickHandler();
+    this.focusHandler = this.getFocusHandler({ 'level' : 'element' });
+
+    this.$elms
+      .on('click', this.clickHandler)
+      .on('focus blur', this.focusHandler);
+  };
+  SelectionButtons.prototype.addDocumentLevelEvents = function () {
+    this.clickHandler = this.getClickHandler();
+    this.focusHandler = this.getFocusHandler({ 'level' : 'document' });
+
+    $(document)
+      .on('click', this.selector, this.clickHandler)
+      .on('focus blur', this.selector, this.focusHandler);
+  };
+  SelectionButtons.prototype.getClickHandler = function () {
+    return function (e) {
+      this.markSelected($(e.target));
+    }.bind(this);
+  };
+  SelectionButtons.prototype.getFocusHandler = function (opts) {
+    var focusEvent = (opts.level === 'document') ? 'focusin' : 'focus';
+
+    return function (e) {
+      var state = (e.type === focusEvent) ? 'focused' : 'blurred';
+
+      this.markFocused($(e.target), state);
+    }.bind(this);
+  };
+  SelectionButtons.prototype.destroy = function () {
+    if (typeof this.selector !== 'undefined') {
+      $(document)
+        .off('click', this.selector, this.clickHandler)
+        .off('focus blur', this.selector, this.focusHandler);
+    } else {
+      this.$elms
+        .off('click', this.clickHandler)
+        .off('focus blur', this.focusHandler);
+    }
+  };
+
+  root.GOVUK.SelectionButtons = SelectionButtons;
+}).call(this);

--- a/app/views/examples/elements/radio-buttons-checkboxes.html
+++ b/app/views/examples/elements/radio-buttons-checkboxes.html
@@ -1,0 +1,98 @@
+{{<layout}}
+
+{{$content}}
+<main id="content" role="main">
+  <a class="link-back" href="/examples/">Back to the GOV.UK prototype kit examples</a>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form action="/" method="post" class="form">
+
+        <h1 class="heading-xlarge">
+          Radio buttons <br> and checkboxes
+        </h1>
+
+        <p>
+          This test page demonstrates selection-buttons.js from the govuk frontend toolkit, which
+          sets 'focused' and 'selected' states for the large hit area labels that wrap checkboxes and radio buttons.
+        </p>
+
+        <p>
+          It also demonstrates setting ARIA attributes when showing and hiding additional content.
+        </p>
+
+        <h2 class="heading-large">
+          What is your nationality?
+        </h2>
+
+        <p>If you have dual nationality, select all options that are relevant to you.</p>
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">What is your nationality?</legend>
+
+            <label for="nationality_british" class="block-label">
+              <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
+              British
+            </label>
+
+            <label for="nationality_irish" class="block-label">
+              <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
+              Irish
+            </label>
+
+            <label for="nationality_other" class="block-label" data-target="example_nationality_other">
+              <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
+              Citizen of another country
+            </label>
+
+            <div class="panel-indent js-hidden" id="example_nationality_other">
+              <label for="nationality_other_countries" class="form-label">
+                Country name
+              </label>
+              <input type="text" id="nationality_other_countries">
+            </div>
+
+          </fieldset>
+        </div>
+
+        <h2 class="heading-large">
+          Which part of the Housing Act was your licence isued under?
+        </h2>
+
+        <p>
+          Select one of the options below.
+        </p>
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">
+              Which part of the Housing Act was your licence isued under?
+            </legend>
+
+            <label for="radio-part-2" class="block-label">
+              <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
+              <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
+              For properties that are 3 or more stories high and occupied by 5 or more people
+            </label>
+
+            <label for="radio-part-3" class="block-label">
+              <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
+              <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
+              For properties that are within a geographical area defined by a local council
+            </label>
+
+          </fieldset>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{{/content}}
+
+{{/layout}}

--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -27,17 +27,22 @@
 		</li>
 		<li>
 			<a href="/examples/elements/forms">
-				Form 
+				Form
+			</a>
+		</li>
+		<li>
+			<a href="/examples/elements/radio-buttons-checkboxes">
+				Form elements - radio buttons and checkboxes
 			</a>
 		</li>
 		<li>
 			<a href="/examples/confirmation">
-				Confirmation 
+				Confirmation
 			</a>
 		</li>
 		<li>
 			<a href="/examples/template-data">
-				Template data 
+				Template data
 			</a>
 		</li>
 		<li>

--- a/app/views/includes/elements_scripts.html
+++ b/app/views/includes/elements_scripts.html
@@ -1,2 +1,0 @@
-<!-- govuk_elements js -->
-<script src="/public/javascripts/details.polyfill.js"></script>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,3 +1,4 @@
 <!-- Javascript -->
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
+<script src="/public/javascripts/govuk/selection-buttons.js"></script>
 <script src="/public/javascripts/application.js"></script>


### PR DESCRIPTION
This adds selected and focused states to the parent label wrapping a
radio button or checkbox.

Create an example page for radio buttons and checkboxes to show how this works.

Link to the example page from the index page.