### PR TITLE
Set example pages to use the same template

### DIFF
--- a/app/views/examples/elements/forms.html
+++ b/app/views/examples/elements/forms.html
@@ -1,8 +1,4 @@
-{{<govuk_template}}
-
-{{$head}}
-  {{>includes/elements_head}}
-{{/head}}
+{{<layout}}
 
 {{$content}}
 <main id="content" role="main">
@@ -83,11 +79,7 @@
 
   </form>
 
-</main><!-- / #page-container -->
+</main>
 {{/content}}
 
-{{$bodyEnd}}
-  {{>includes/elements_scripts}}
-{{/bodyEnd}}
-
-{{/govuk_template}}
+{{/layout}}

--- a/app/views/examples/elements/grid-layout.html
+++ b/app/views/examples/elements/grid-layout.html
@@ -1,8 +1,4 @@
-{{<govuk_template}}
-
-{{$head}}
-  {{>includes/elements_head}}
-{{/head}}
+{{<layout}}
 
 {{$content}}
 <main id="content" role="main">
@@ -120,4 +116,4 @@
 </main>
 {{/content}}
 
-{{/govuk_template}}
+{{/layout}}

--- a/app/views/examples/elements/typography.html
+++ b/app/views/examples/elements/typography.html
@@ -1,8 +1,4 @@
-{{<govuk_template}}
-
-{{$head}}
-  {{>includes/elements_head}}
-{{/head}}
+{{<layout}}
 
 {{$content}}
 <main id="content" role="main">
@@ -56,7 +52,7 @@
 
   </div>
 
-</main><!-- / #page-container -->
+</main>
 {{/content}}
 
-{{/govuk_template}}
+{{/layout}}

--- a/app/views/includes/elements_head.html
+++ b/app/views/includes/elements_head.html
@@ -1,1 +1,0 @@
-<link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" />

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,3 +1,4 @@
 <!-- Javascript -->
+<script src="/public/javascripts/details.polyfill.js"></script>
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/application.js"></script>


### PR DESCRIPTION
This PR expects that #57 has been merged first. 

All example pages now use the same layout template, header and scripts includes.

The details summary polyfill is moved to the scripts include, so will be available to all templates.