### PR TITLE
Remove H1, add survey link

### DIFF
--- a/app/views/examples/confirmation.html
+++ b/app/views/examples/confirmation.html
@@ -21,7 +21,7 @@
       <h2 class="heading-medium">What happens next?</h2>
       <p>We've sent your application to Hackney Electoral Register Office.</p>
       <p>They will contact you either to confirm your registration, or to ask for more information.</p>
-      <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a></p>
+      <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
 
     </div>
   </div>

--- a/app/views/examples/confirmation.html
+++ b/app/views/examples/confirmation.html
@@ -10,7 +10,7 @@
     <div class="column-two-thirds">
 
       <div class="govuk-box-highlight">
-        <h2 class="bold-large">Application complete</h2>
+        <h1 class="bold-large">Application complete</h1>
         <p>
           Your reference number is <br>
           <strong class="heading-medium">HDJ2123F</strong>

--- a/app/views/examples/confirmation.html
+++ b/app/views/examples/confirmation.html
@@ -9,10 +9,6 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <h1 class="heading-xlarge">
-        Example service name
-      </h1>
-
       <div class="govuk-box-highlight">
         <h2 class="bold-large">Application complete</h2>
         <p>
@@ -25,6 +21,7 @@
       <h2 class="heading-medium">What happens next?</h2>
       <p>We've sent your application to Hackney Electoral Register Office.</p>
       <p>They will contact you either to confirm your registration, or to ask for more information.</p>
+      <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a></p>
 
     </div>
   </div>


### PR DESCRIPTION
Two small changes: 

1. Removed service name H1 following discussion on Slack, as the emphasis on this page should not be on the service title (at least not as an H1)

2. Added a feedback link: "What did you think of this service? (takes 30 seconds)"

<img width="683" alt="new_conf_page" src="https://cloud.githubusercontent.com/assets/90854/11002061/7708a900-84a2-11e5-856d-2d6de4ab4794.png">
