### PR TITLE
Add js to show and hide related content for radios and checkboxes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,8 +1,127 @@
+function ShowHideContent() {
+  var self = this;
+
+  self.escapeElementName = function(str) {
+    result = str.replace('[', '\\[').replace(']', '\\]')
+    return(result);
+  };
+
+  self.showHideRadioToggledContent = function () {
+    $(".block-label input[type='radio']").each(function () {
+
+      var $radio = $(this);
+      var $radioGroupName = $radio.attr('name');
+      var $radioLabel = $radio.parent('label');
+
+      var dataTarget = $radioLabel.attr('data-target');
+
+      // Add ARIA attributes
+
+      // If the data-target attribute is defined
+      if (dataTarget) {
+
+        // Set aria-controls
+        $radio.attr('aria-controls', dataTarget);
+
+        $radio.on('click', function () {
+
+          // Select radio buttons in the same group
+          $radio.closest('form').find(".block-label input[name=" + self.escapeElementName($radioGroupName) + "]").each(function () {
+            var $this = $(this);
+
+            var groupDataTarget = $this.parent('label').attr('data-target');
+            var $groupDataTarget = $('#' + groupDataTarget);
+
+            // Hide toggled content
+            $groupDataTarget.hide();
+            // Set aria-expanded and aria-hidden for hidden content
+            $this.attr('aria-expanded', 'false');
+            $groupDataTarget.attr('aria-hidden', 'true');
+          });
+
+          var $dataTarget = $('#' + dataTarget);
+          $dataTarget.show();
+          // Set aria-expanded and aria-hidden for clicked radio
+          $radio.attr('aria-expanded', 'true');
+          $dataTarget.attr('aria-hidden', 'false');
+
+        });
+
+      } else {
+        // If the data-target attribute is undefined for a radio button,
+        // hide visible data-target content for radio buttons in the same group
+
+        $radio.on('click', function () {
+
+          // Select radio buttons in the same group
+          $(".block-label input[name=" + self.escapeElementName($radioGroupName) + "]").each(function () {
+
+            var groupDataTarget = $(this).parent('label').attr('data-target');
+            var $groupDataTarget = $('#' + groupDataTarget);
+
+            // Hide toggled content
+            $groupDataTarget.hide();
+            // Set aria-expanded and aria-hidden for hidden content
+            $(this).attr('aria-expanded', 'false');
+            $groupDataTarget.attr('aria-hidden', 'true');
+          });
+
+        });
+      }
+
+    });
+  }
+  self.showHideCheckboxToggledContent = function () {
+
+    $(".block-label input[type='checkbox']").each(function() {
+
+      var $checkbox = $(this);
+      var $checkboxLabel = $(this).parent();
+
+      var $dataTarget = $checkboxLabel.attr('data-target');
+
+      // Add ARIA attributes
+
+      // If the data-target attribute is defined
+      if (typeof $dataTarget !== 'undefined' && $dataTarget !== false) {
+
+        // Set aria-controls
+        $checkbox.attr('aria-controls', $dataTarget);
+
+        // Set aria-expanded and aria-hidden
+        $checkbox.attr('aria-expanded', 'false');
+        $('#'+$dataTarget).attr('aria-hidden', 'true');
+
+        // For checkboxes revealing hidden content
+        $checkbox.on('click', function() {
+
+          var state = $(this).attr('aria-expanded') === 'false' ? true : false;
+
+          // Toggle hidden content
+          $('#'+$dataTarget).toggle();
+
+          // Update aria-expanded and aria-hidden attributes
+          $(this).attr('aria-expanded', state);
+          $('#'+$dataTarget).attr('aria-hidden', !state);
+
+        });
+      }
+
+    });
+  }
+}
+
 $(document).ready(function() {
 
   // Use GOV.UK selection-buttons.js to set selected
   // and focused states for block labels
   var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']");
   new GOVUK.SelectionButtons($blockLabels);
+
+  // Show and hide toggled content
+  // Where .block-label uses the data-target attribute
+  var toggleContent = new ShowHideContent();
+  toggleContent.showHideRadioToggledContent();
+  toggleContent.showHideCheckboxToggledContent();
 
 });

--- a/app/views/examples/elements/toggled-content.html
+++ b/app/views/examples/elements/toggled-content.html
@@ -1,0 +1,116 @@
+{{<layout}}
+
+{{$content}}
+<main id="content" role="main">
+  <a class="link-back" href="/examples/">Back to the GOV.UK prototype kit examples</a>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form action="/" method="post" class="form">
+
+        <h1 class="heading-xlarge">
+          Toggled content
+        </h1>
+
+        <p>
+          This page shows how to use the <code class="code">data-target</code> attribute to show and hide content when a radio button or checkbox is selected.
+        </p>
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">What is your nationality?</legend>
+
+            <label for="nationality_british" class="block-label">
+              <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
+              British
+            </label>
+
+            <label for="nationality_irish" class="block-label">
+              <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
+              Irish
+            </label>
+
+            <label for="nationality_other" class="block-label" data-target="example_nationality_other">
+              <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
+              Citizen of another country
+            </label>
+
+            <div class="panel-indent js-hidden" id="example_nationality_other">
+              <label for="nationality_other_countries" class="form-label">
+                Country name
+              </label>
+              <input type="text" id="nationality_other_countries">
+            </div>
+
+          </fieldset>
+        </div>
+
+        <h1 class="heading-large">
+          Where should we send your new<br> passport?
+        </h1>
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">
+              Where should we send your new passport?
+            </legend>
+
+            <label for="radio-home-address" class="block-label">
+              <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
+              Home address
+            </label>
+
+            <label for="radio-other-address" class="block-label" data-target="example-other-address">
+              <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
+              Other address
+            </label>
+
+            <div class="panel-indent js-hidden" id="example-other-address">
+
+              <h2 class="heading-medium">
+                Your other address
+              </h2>
+
+              <fieldset>
+
+                <legend class="visuallyhidden">
+                  Your other address
+                </legend>
+
+                <div class="form-group form-group-compound">
+                  <label class="form-label" for="address-line-1">Street</label>
+                  <input type="text" class="form-control" id="address-line-1">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label visuallyhidden" for="address-line-2">Street</label>
+                  <input type="text" class="form-control" id="address-line-2">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="address-town">Town or City</label>
+                  <input type="text" class="form-control form-control-1-4" id="address-town">
+                </div>
+
+                <div class="form-group">
+                  <label class="form-label" for="address-postcode">Postcode</label>
+                  <input type="text" class="form-control form-control-1-8" id="address-postcode">
+                </div>
+
+              </fieldset>
+
+            </div>
+          </fieldset>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{{/content}}
+
+{{/layout}}

--- a/app/views/examples/elements/toggled-content.html
+++ b/app/views/examples/elements/toggled-content.html
@@ -22,26 +22,26 @@
 
             <legend class="visuallyhidden">What is your nationality?</legend>
 
-            <label for="nationality_british" class="block-label">
+            <label class="block-label" for="nationality_british">
               <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
               British
             </label>
 
-            <label for="nationality_irish" class="block-label">
+            <label class="block-label" for="nationality_irish">
               <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
               Irish
             </label>
 
-            <label for="nationality_other" class="block-label" data-target="example_nationality_other">
+            <label class="block-label" for="nationality_other" data-target="example_nationality_other">
               <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
               Citizen of another country
             </label>
 
             <div class="panel-indent js-hidden" id="example_nationality_other">
-              <label for="nationality_other_countries" class="form-label">
+              <label class="form-label" for="nationality_other_countries">
                 Country name
               </label>
-              <input type="text" id="nationality_other_countries">
+              <input class="form-control" type="text" id="nationality_other_countries">
             </div>
 
           </fieldset>
@@ -58,12 +58,12 @@
               Where should we send your new passport?
             </legend>
 
-            <label for="radio-home-address" class="block-label">
+            <label class="block-label" for="radio-home-address" >
               <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
               Home address
             </label>
 
-            <label for="radio-other-address" class="block-label" data-target="example-other-address">
+            <label class="block-label" for="radio-other-address" data-target="example-other-address">
               <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
               Other address
             </label>
@@ -82,22 +82,22 @@
 
                 <div class="form-group form-group-compound">
                   <label class="form-label" for="address-line-1">Street</label>
-                  <input type="text" class="form-control" id="address-line-1">
+                  <input class="form-control" type="text" id="address-line-1">
                 </div>
 
                 <div class="form-group">
                   <label class="form-label visuallyhidden" for="address-line-2">Street</label>
-                  <input type="text" class="form-control" id="address-line-2">
+                  <input class="form-control" type="text" id="address-line-2">
                 </div>
 
                 <div class="form-group">
                   <label class="form-label" for="address-town">Town or City</label>
-                  <input type="text" class="form-control form-control-1-4" id="address-town">
+                  <input class="form-control form-control-1-4" type="text" id="address-town">
                 </div>
 
                 <div class="form-group">
                   <label class="form-label" for="address-postcode">Postcode</label>
-                  <input type="text" class="form-control form-control-1-8" id="address-postcode">
+                  <input class="form-control form-control-1-8" type="text" id="address-postcode">
                 </div>
 
               </fieldset>

--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -7,56 +7,63 @@
 {{$content}}
 
 <main id="content" role="main">
-
-	<h1 class="heading-xlarge">Example pages</h1>
-	<ul class="list-bullet">
-		<li>
-			<a href="/examples/blank">
-				Blank page
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/grid-layout">
-				Grid layout
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/typography">
-				Typography
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/forms">
-				Form
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/radio-buttons-checkboxes">
-				Form elements - radio buttons and checkboxes
-			</a>
-		</li>
-		<li>
-			<a href="/examples/confirmation">
-				Confirmation
-			</a>
-		</li>
-		<li>
-			<a href="/examples/template-data">
-				Template data
-			</a>
-		</li>
-		<li>
-			<a href="/examples/unbranded">
-				Blank page - without GOV.UK header and footer
-			</a>
-		</li>
-		<li>
-			<a href="/examples/template-partial-areas">
-				Template partial areas
-			</a>
-		</li>
-	</ul>
-
+	<div class="grid-row">
+		<div class="column-two-thirds">
+			<h1 class="heading-xlarge">Example pages</h1>
+			<ul class="list-bullet">
+				<li>
+					<a href="/examples/blank">
+						Blank page
+					</a>
+				</li>
+				<li>
+					<a href="/examples/elements/grid-layout">
+						Grid layout
+					</a>
+				</li>
+				<li>
+					<a href="/examples/elements/typography">
+						Typography
+					</a>
+				</li>
+				<li>
+					<a href="/examples/elements/forms">
+						Form
+					</a>
+				</li>
+				<li>
+					<a href="/examples/elements/radio-buttons-checkboxes">
+						Form elements - radio buttons and checkboxes
+					</a>
+				</li>
+				<li>
+					<a href="/examples/elements/toggled-content">
+						Toggled content - show additional content when a radio button or checkbox is selected
+					</a>
+				</li>
+				<li>
+					<a href="/examples/confirmation">
+						Confirmation
+					</a>
+				</li>
+				<li>
+					<a href="/examples/template-data">
+						Template data
+					</a>
+				</li>
+				<li>
+					<a href="/examples/unbranded">
+						Blank page - without GOV.UK header and footer
+					</a>
+				</li>
+				<li>
+					<a href="/examples/template-partial-areas">
+						Template partial areas
+					</a>
+				</li>
+			</ul>
+		</div>
+	</div>
 </main>
 
 {{/content}}


### PR DESCRIPTION
This PR adds the the js for toggling content from govuk elements.

The label of the checkbox or radio button (for which the additional content should be shown) must have a data-target attribute, which is the same as the ID of the hidden content. 

An example page demonstrates how this works. Screenshot below.

![gov uk the best place to find government services and information](https://cloud.githubusercontent.com/assets/417754/11002076/93db2b84-84a2-11e5-889b-feb567ee6ad1.png)

This fixes #51.
