### PR TITLE
Update govuk elements form styles

### DIFF
--- a/app/assets/sass/elements/_forms.scss
+++ b/app/assets/sass/elements/_forms.scss
@@ -78,16 +78,6 @@ textarea{
   margin-bottom: 10px;
 }
 
-// Form title
-// TODO: Remove this (duplication of existing heading styles)
-.form-title {
-  margin-bottom: $gutter;
-
-  @include media(tablet) {
-    margin-bottom: ($gutter*1.5);
-  }
-}
-
 
 // 4. Form labels
 // ==========================================================================
@@ -125,16 +115,18 @@ legend {
   }
 }
 
-// Used for paragraphs in-between form elements
+// Used for the 'or' in between block label options
 .form-block {
   @extend %contain-floats;
   float: left;
   width: 100%;
 
+  margin-top: -5px;
   margin-bottom: 5px;
 
   @include media(tablet) {
-    margin-top: 10px;
+    margin-top: 0;
+    margin-bottom: 10px;
   }
 }
 
@@ -163,7 +155,7 @@ legend {
 
   padding: 4px;
   background-color: $white;
-  border: 1px solid $border-colour;
+  border: 2px solid $grey-1;
 
   // TODO: Remove 50% width set for tablet and up
   // !! BREAKING CHANGE !!


### PR DESCRIPTION
Amend the border for form controls
- this is now 2px wide and a darker grey

Also adjust the spacing for paragraphs in-between radio buttons or
checkboxes.

![gov uk the best place to find government services and information](https://cloud.githubusercontent.com/assets/417754/11031794/dd9dd7ac-86ce-11e5-8be2-9ac81ec9de6e.png)

cc. @rivalee.