### PR TITLE
Add grid layout wrappers to the example page

### DIFF
--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -1,72 +1,74 @@
 {{<layout}}
 
 {{$pageTitle}}
-	GOV.UK prototyping kit
+  GOV.UK prototyping kit
 {{/pageTitle}}
 
 {{$content}}
 
 <main id="content" role="main">
-
-	<h1 class="heading-xlarge">Example pages</h1>
-	<ul class="list-bullet">
-		<li>
-			<a href="/examples/blank">
-				Blank page
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/grid-layout">
-				Grid layout
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/typography">
-				Typography
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/forms">
-				Form
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/radio-buttons-checkboxes">
-				Form elements - radio buttons and checkboxes
-			</a>
-		</li>
-		<li>
-			<a href="/examples/elements/toggled-content">
-				Toggled content - show additional content when a radio button or checkbox is selected
-			</a>
-		</li>
-		<li>
-			<a href="/examples/confirmation">
-				Confirmation
-			</a>
-		</li>
-		<li>
-			<a href="/examples/start-page">
-				Start page
-			</a>
-		</li>
-		<li>
-			<a href="/examples/template-data">
-				Template data
-			</a>
-		</li>
-		<li>
-			<a href="/examples/unbranded">
-				Blank page - without GOV.UK header and footer
-			</a>
-		</li>
-		<li>
-			<a href="/examples/template-partial-areas">
-				Template partial areas
-			</a>
-		</li>
-	</ul>
-
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge">Example pages</h1>
+      <ul class="list-bullet">
+        <li>
+          <a href="/examples/blank">
+            Blank page
+          </a>
+        </li>
+        <li>
+          <a href="/examples/elements/grid-layout">
+            Grid layout
+          </a>
+        </li>
+        <li>
+          <a href="/examples/elements/typography">
+            Typography
+          </a>
+        </li>
+        <li>
+          <a href="/examples/elements/forms">
+            Form
+          </a>
+        </li>
+        <li>
+          <a href="/examples/elements/radio-buttons-checkboxes">
+            Form elements - radio buttons and checkboxes
+          </a>
+        </li>
+        <li>
+          <a href="/examples/elements/toggled-content">
+            Toggled content - show additional content when a radio button or checkbox is selected
+          </a>
+        </li>
+        <li>
+          <a href="/examples/confirmation">
+            Confirmation
+          </a>
+        </li>
+        <li>
+          <a href="/examples/start-page">
+            Start page
+          </a>
+        </li>
+        <li>
+          <a href="/examples/template-data">
+            Template data
+          </a>
+        </li>
+        <li>
+          <a href="/examples/unbranded">
+            Blank page - without GOV.UK header and footer
+          </a>
+        </li>
+        <li>
+          <a href="/examples/template-partial-areas">
+            Template partial areas
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </main>
 
 {{/content}}


### PR DESCRIPTION
- Add a grid row wrapper
- Place content in a 2/3 width grid column

Also trim trailing whitespace and use a two-space indent.

Before:
![before - gov uk prototyping kit](https://cloud.githubusercontent.com/assets/417754/11036930/0d37690a-86f3-11e5-9467-1ca699739852.png)


After:

![after - gov uk prototyping kit](https://cloud.githubusercontent.com/assets/417754/11036983/5366918a-86f3-11e5-9220-6f504a6be5a5.png)
