### PR TITLE
Remove node-sass from package.json to stop npm install failing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "hogan.js": "3.0.2",
     "govuk_frontend_toolkit": "^4.2.1",
     "govuk_template_mustache": "^0.15.1",
-    "node-sass": "3.4.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "hogan.js": "3.0.2",
     "govuk_frontend_toolkit": "^4.2.1",
     "govuk_template_mustache": "^0.15.1",
-    "node-sass": "3.3.3",
+    "node-sass": "3.4.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.5.0",


### PR DESCRIPTION
Hi all,

I've been having issues with getting npm install to complete using Node v5.0.0 due to node-sass. Bumping the node-sass version to the latest release fixes these issues.