### PR TITLE
Change 'prototyping' to 'prototype'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 1.0.0
 
-Initial release of prototyping kit
+Initial release of prototype kit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GOV.UK Prototyping Kit
+# GOV.UK Prototype kit
 
 The kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
 
@@ -68,7 +68,7 @@ The app recompiles app/assets/stylesheets/application.scss everytime changes are
 
 ## Documentation
 
-- [Prototyping kit principles](docs/principles.md)
+- [Prototype kit principles](docs/principles.md)
 - [Getting started](docs/getting-started.md)
 - [Making pages](docs/making-pages.md)
 - [Writing CSS](docs/writing-css.md)
@@ -83,5 +83,5 @@ This project is built on top of Express, the idea is that it is straightforward 
 
 We have two Slack channels for this app. You'll need a government email address to join them.
 
-* [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+* [Slack channel for users of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
+* [Slack channel for developers of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)

--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -1,7 +1,7 @@
 {{<layout}}
 
 {{$pageTitle}}
-  GOV.UK prototyping kit
+  GOV.UK prototype kit
 {{/pageTitle}}
 
 {{$content}}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,7 +1,7 @@
 {{<layout}}
 
 {{$pageTitle}}
-	GOV.UK prototyping kit
+	GOV.UK prototype kit
 {{/pageTitle}}
 
 {{$content}}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -8,7 +8,7 @@
 
 <main id="content" role="main">
 
-	<h1 class="heading-xlarge">Welcome to the GOV.UK prototyping kit</h1>
+	<h1 class="heading-xlarge">Welcome to the GOV.UK prototype kit</h1>
 	<!-- feel free to change this page to suit your needs -->
 
 	<p>This is the index.html page - we recommend you put links to key pages here.</p>
@@ -26,7 +26,7 @@
 	<ul class="list-bullet">
 		<li>
 			<a href="https://github.com/alphagov/govuk_prototype_kit/tree/master/docs">
-				GOV.UK kit documentation
+				GOV.UK prototype kit documentation
 			</a>
 		</li>
 		<li>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-- [Prototyping kit principles](principles.md)
+- [Prototype kit principles](principles.md)
 - [Getting started](getting-started.md)
 - [Making pages](making-pages.md)
 - [Writing CSS](writing-css.md)

--- a/docs/making-pages.md
+++ b/docs/making-pages.md
@@ -12,7 +12,7 @@ For more complex prototypes, you will need to use Mustache.
 
 ## Mustache
 
-All templates used in the prototyping application (app) should be written in the Mustache language. Its specification is listed on [this page](http://mustache.github.io/mustache.5.html).
+All templates used in the prototype kit should be written in the Mustache language. Its specification is listed on [this page](http://mustache.github.io/mustache.5.html).
 
 ### A quick example (from the specification):
 
@@ -41,7 +41,7 @@ Will produce the following:
 
 ### Using Mustache in the app
 
-When working with the prototyping app, your version of the above exists like so:
+When working with the prototype kit, your version of the above exists like so:
 
 The following route (where the `response` parameter is `res`) would sit in [routes.js](../app/routes.js):
 
@@ -89,7 +89,7 @@ When a page is requested, the templating language will work out what it should i
 
 ### Mustache inheritance
 
-As well as the features you get in standard Mustache, the prototyping app also contains an implementation of [this proposal](https://gist.github.com/spullara/1854699) for template inheritance.
+As well as the features you get in standard Mustache, the prototype kit also contains an implementation of [this proposal](https://gist.github.com/spullara/1854699) for template inheritance.
 
 That Gist explains it pretty well, you can have many levels of inheritance but they are all doing one thing: specifying what appears in certain blocks of the page.
 
@@ -171,7 +171,7 @@ Try using the `views/logo.html` file in your base template like so:
     
 The `views/logo.html` should be:
 
-    <p>Prototyping application</p>
+    <p>Prototype kit</p>
     
 You should find the resulting HTML page will be:
 
@@ -180,7 +180,7 @@ You should find the resulting HTML page will be:
             <title>Inheritance test page</title>
         </head>
         <body>
-            <p>Prototyping application</p>
+            <p>Prototype kit</p>
             <p>Section: Guides</p>
             <h1>Inheritance test page</h1>
             <p>Hello world</p>
@@ -211,7 +211,7 @@ All partials are kept in the [includes](../app/views/includes/) folder.
 
 ## Inheriting the GOV.UK template
 
-Pages in the prototyping app are set up to use the [govuk_template](https://github.com/alphagov/govuk_template) as the base template in an inheritance chain. Have a look at the template files `views/layout.html` and `views/index.html` to see an example.
+Pages in the prototype kit are set up to use the [govuk_template](https://github.com/alphagov/govuk_template) as the base template in an inheritance chain. Have a look at the template files `views/layout.html` and `views/index.html` to see an example.
 
 ### Template blocks
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,6 +1,6 @@
 # Principles
 
-The prototyping kit:
+The prototype kit:
 
 - is designed for prototyping, not for production code
 - is as simple as possible without teaching bad habits

--- a/docs/writing-css.md
+++ b/docs/writing-css.md
@@ -1,6 +1,6 @@
 # Writing CSS
 
-CSS used in the prototyping application (app) is written in the SCSS syntax of [Sass](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax). 
+CSS used in the prototype kit is written in the SCSS syntax of [Sass](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax). 
 
 ## Sass
 
@@ -10,7 +10,7 @@ SCSS was chosen because you can paste CSS into it without breaking it which is u
 
 ## We use Node Sass
 
-The prototyping app uses [node-sass](https://github.com/andrew/node-sass), a node version of of [lib-sass](https://github.com/hcatlin/libsass). It's still a work in progress and so you may find a few things don't work, the most important of which is that [@extend](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#extend) mostly doesn't. 
+The prototype kit uses [node-sass](https://github.com/andrew/node-sass), a node version of of [lib-sass](https://github.com/hcatlin/libsass). It's still a work in progress and so you may find a few things don't work, the most important of which is that [@extend](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#extend) mostly doesn't. 
 
 We found most other features are in and development is progressing quick enough to work with most prototypes (any bugs we found were quickly fixed). Note that `@extend` is used in just one place in the toolkit: the `clear-floats` @extend in [_shims.scss](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_shims.scss).
 
@@ -26,7 +26,7 @@ Your best bet is to use the Ruby version of Sass to compile your SCSS. Functiona
 
 ## Writing code
 
-You write your Sass in [app/assets/sass](../app/assets/sass) and the prototyping app will compile it into the CSS used in your page (found in /public/stylesheets). The app watches your files so this will happen automatically.
+You write your Sass in [app/assets/sass](../app/assets/sass) and the prototype kit will compile it into the CSS used in your page (found in /public/stylesheets). The app watches your files so this will happen automatically.
 
 There is already a CSS file included to use called [application.scss](../app/assets/sass/application.scss) which compiles into [application.css](../public/stylesheets/application.css). Note that Sass files are identified by the `.scss` extension.
 


### PR DESCRIPTION
For consistency, use the phrase 'prototype kit' instead of 'prototyping kit' or 'prototyping app'.