### PR TITLE
Add default cookie message from GOV.UK to layout.html

### DIFF
--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -4,7 +4,7 @@ module.exports = {
   bodyClasses: "{{$bodyClasses}}{{/bodyClasses}}",
   bodyEnd: "{{$bodyEnd}}{{/bodyEnd}}",
   content: "{{$content}}{{/content}}",
-  cookieMessage: "{{$cookieMessage}}{{/cookieMessage}}",
+  cookieMessage: "{{$cookieMessage}}<p>GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a></p>{{/cookieMessage}}",
   crownCopyrightMessage: "{{$crownCopyrightMessage}}© Crown copyright{{/crownCopyrightMessage}}",
   footerSupportLinks: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
   footerTop: "{{$footerTop}}{{/footerTop}}",

--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -4,7 +4,7 @@ module.exports = {
   bodyClasses: "{{$bodyClasses}}{{/bodyClasses}}",
   bodyEnd: "{{$bodyEnd}}{{/bodyEnd}}",
   content: "{{$content}}{{/content}}",
-  cookieMessage: "{{$cookieMessage}}<p>GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a></p>{{/cookieMessage}}",
+  cookieMessage: "{{$cookieMessage}}<p>GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a></p>{{/cookieMessage}}",
   crownCopyrightMessage: "{{$crownCopyrightMessage}}© Crown copyright{{/crownCopyrightMessage}}",
   footerSupportLinks: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
   footerTop: "{{$footerTop}}{{/footerTop}}",


### PR DESCRIPTION
Add a default cookie message to layout.html to match what GOV.UK uses. Rather than a blank blue bar on first load, users will now see a cookie message.

Before:
![screen shot 2015-11-30 at 15 39 14](https://cloud.githubusercontent.com/assets/2204224/11476050/974b0062-9778-11e5-89c5-732c27734c14.png)

After:
![screen shot 2015-11-30 at 15 39 33](https://cloud.githubusercontent.com/assets/2204224/11476058/9db6b9f0-9778-11e5-9355-9bab1c978773.png)
