### PR TITLE
Improve authentication guidance and error messaging

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -29,7 +29,10 @@ heroku config:set USERNAME=username_here
 heroku config:set PASSWORD=password_here
 ```
 
-
+If you don't want to have password protection on your prototype, you can set the `USE_AUTH` config var:
+```
+heroku config:set USE_AUTH=false
+```
 ### 4) Deploy changes
 
 If you make a change to your prototype, commit your changes as usual then run:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,14 +17,14 @@ exports.basicAuth = function(username, password) {
 
 		if (!username || !password) {
 			console.log('Username or password is not set.');
-			return res.send('Error: username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>.');
+			return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>.</p>');
 		}
 		
 		var user = basicAuth(req);
 
 		if (!user || user.name !== username || user.pass !== password) {
 			res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
-			return res.send(401);
+			return res.sendStatus(401);
 		}
 
 		next();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,7 @@ exports.basicAuth = function(username, password) {
 
 		if (!username || !password) {
 			console.log('Username or password is not set.');
-			return res.send('Error: username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>');
+			return res.send('Error: username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>.');
 		}
 		
 		var user = basicAuth(req);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,32 @@
+var basicAuth = require('basic-auth');
+
+/**
+ * Simple basic auth middleware for use with Express 4.x.
+ *
+ * Based on template found at: http://www.danielstjules.com/2014/08/03/basic-auth-with-express-4/
+ *
+ * @example
+ * app.use('/api-requiring-auth', utils.basicAuth('username', 'password'));
+ *
+ * @param   {string}   username Expected username
+ * @param   {string}   password Expected password
+ * @returns {function} Express 4 middleware requiring the given credentials
+ */
+exports.basicAuth = function(username, password) {
+	return function(req, res, next) {
+
+		if (!username || !password) {
+			console.log('Username or password is not set.');
+			return res.send('Error: username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>');
+		}
+		
+		var user = basicAuth(req);
+
+		if (!user || user.name !== username || user.pass !== password) {
+			res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
+			return res.send(401);
+		}
+
+		next();
+	};
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "4.x"
   },
   "dependencies": {
-    "basic-auth-connect": "1.0.0",
+    "basic-auth": "^1.0.3",
     "body-parser": "^1.14.1",
     "consolidate": "0.x",
     "express": "4.13.3",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-var path = require('path'),
+var path  = require('path'),
     express = require('express'),
     routes = require(__dirname + '/app/routes.js'),
     favicon = require('serve-favicon'),
@@ -11,12 +11,15 @@ var path = require('path'),
 // Grab environment variables specified in Procfile or as Heroku config vars
     username = process.env.USERNAME,
     password = process.env.PASSWORD,
-    env = process.env.NODE_ENV || 'development';
-    useAuth = process.env.USE_AUTH || true;
+    env      = process.env.NODE_ENV || 'development',
+    useAuth  = process.env.USE_AUTH || 'true';
+
+    env      = env.toLowerCase();
+    useAuth  = useAuth.toLowerCase();
 
 // Authenticate against the environment-provided credentials if running
 // the app in production (Heroku, effectively)
-if (env === 'production' && useAuth === true){
+if (env === 'production' && useAuth === 'true'){
     app.use(utils.basicAuth(username, password));
 }
 

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ var path = require('path'),
 
 // Authenticate against the environment-provided credentials if running
 // the app in production (Heroku, effectively)
-if ((env === 'production') && (useAuth === true)){
+if (env === 'production' && useAuth === true){
     app.use(utils.basicAuth(username, password));
 }
 


### PR DESCRIPTION
This pr provides a more helpful error message if users have not set a username or password on production.

Changes:
* Display error message if username or password not set in production (rather than exiting)
* Move to `basic-auth` rather than `basic-auth-connect` which is depreciated.
* Add config var to let users enable or disable auth
* Update docs.

fixes #91 