### PR TITLE
Improve error handling around port in use, find new port

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,8 +71,8 @@ exports.findAvailablePort = function(app){
         }
         else {
           // User answers no - exit
-          console.log('You can set a new default port in server.js, or by running the server with PORT=XXXX');
-          console.log("Exiting");
+          console.log('\nYou can set a new default port in server.js, or by running the server with PORT=XXXX');
+          console.log("\nExit by pressing 'ctrl + c'");
           process.exit(0);
         }
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,6 @@
-var basicAuth = require('basic-auth');
+var basicAuth = require('basic-auth'),
+    prompt = require('prompt'),
+    portScanner = require('portscanner');
 
 /**
  * Simple basic auth middleware for use with Express 4.x.
@@ -30,3 +32,51 @@ exports.basicAuth = function(username, password) {
 		next();
 	};
 };
+
+exports.findAvailablePort = function(app){
+
+  var port = (process.env.PORT || 3000);
+
+  console.log('');
+  // Check that default port is free, else offer to change
+  portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
+
+    if (port == availablePort){
+      app.listen(port);
+      console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+    }
+    else {
+      // Default port in use - offer to change to available port
+      console.log("ERROR: Port " + port + " in use - you may have another prototype running.\n");
+      // Set up prompt settings
+      prompt.colors = false;
+      prompt.start();
+      prompt.message = "";
+      prompt.delimiter = "";
+
+      // Ask user if they want to change port
+      prompt.get([{
+        name: 'answer',
+        description: 'Change to an available port? (y/n)',
+        required: true,
+        type: 'string',
+        pattern: /y(es)?|no?/i,
+        message: 'Please enter y or n'
+      }], function (err, result) {
+        if (result.answer.match(/y(es)?/i) ) {
+          // User answers yes
+          port = availablePort;
+          app.listen(port);
+          console.log('Changed to port ' + port + '   url: http://localhost:' + port);
+        }
+        else {
+          // User answers no - exit
+          console.log('You can set a new default port in server.js, or by running the server with PORT=XXXX');
+          console.log("Exiting");
+          process.exit(0);
+        }
+      });
+    }
+  });
+
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,7 +47,7 @@ exports.findAvailablePort = function(app){
     }
     else {
       // Default port in use - offer to change to available port
-      console.log("ERROR: Port " + port + " in use - you may have another prototype running.\n");
+      console.error("ERROR: Port " + port + " in use - you may have another prototype running.\n");
       // Set up prompt settings
       prompt.colors = false;
       prompt.start();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "hogan.js": "3.0.2",
     "minimist": "0.0.8",
     "node-sass": "3.3.3",
+    "portscanner": "^1.0.0",
+    "prompt": "^0.2.14",
     "readdir": "0.0.6",
     "serve-favicon": "2.3.0"
   }

--- a/server.js
+++ b/server.js
@@ -5,10 +5,7 @@ var path  = require('path'),
     app = express(),
     basicAuth = require('basic-auth'),
     bodyParser = require('body-parser'),
-    port = (process.env.PORT || 3000),
     utils = require(__dirname + '/lib/utils.js'),
-    prompt = require('prompt'),
-    portScanner = require('portscanner'),
 
 // Grab environment variables specified in Procfile or as Heroku config vars
     username = process.env.USERNAME,
@@ -81,45 +78,4 @@ app.get(/^\/([^.]+)$/, function (req, res) {
 
 // start the app
 
-console.log('');
-// Check that default port is free, else offer to change
-portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
-
-  if (port == availablePort){
-    app.listen(port);
-    console.log('Listening on port ' + port + '   url: http://localhost:' + port);
-  }
-  else {
-    // Default port in use - offer to change to available port
-    console.log("ERROR: Port " + port + " in use - do you have another prototype running?\n");
-    // Set up prompt settings
-    prompt.colors = false;
-    prompt.start();
-    prompt.message = "";
-    prompt.delimiter = "";
-
-    // Ask user if they want to change port
-    prompt.get([{
-      name: 'answer',
-      description: 'Change to an available port? (y/n)',
-      required: true,
-      type: 'string',
-      pattern: /y(es)?|no?/i,
-      message: 'Please enter y or n'
-    }], function (err, result) {
-      if (result.answer.match(/y(es)?/i) ) {
-        // User answers yes
-        port = availablePort;
-        app.listen(port);
-        console.log('Changed to port ' + port + '   url: http://localhost:' + port);
-      }
-      else {
-        // User answers no - exit
-        console.log('You can set a new default port in server.js, or by running the server with PORT=XXXX');
-        console.log("Exiting");
-        process.exit(0);
-      }
-    });
-  }
-});
-
+utils.findAvailablePort(app);

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ var path  = require('path'),
     bodyParser = require('body-parser'),
     port = (process.env.PORT || 3000),
     utils = require(__dirname + '/lib/utils.js'),
+    prompt = require('prompt'),
+    portScanner = require('portscanner'),
 
 // Grab environment variables specified in Procfile or as Heroku config vars
     username = process.env.USERNAME,
@@ -17,7 +19,7 @@ var path  = require('path'),
     env      = env.toLowerCase();
     useAuth  = useAuth.toLowerCase();
 
-// Authenticate against the environment-provided credentials if running
+// Authenticate against the environment-provided credentials, if running
 // the app in production (Heroku, effectively)
 if (env === 'production' && useAuth === 'true'){
     app.use(utils.basicAuth(username, password));
@@ -79,7 +81,45 @@ app.get(/^\/([^.]+)$/, function (req, res) {
 
 // start the app
 
-app.listen(port);
 console.log('');
-console.log('Listening on port ' + port);
-console.log('');
+// Check that default port is free, else offer to change
+portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
+
+  if (port == availablePort){
+    app.listen(port);
+    console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+  }
+  else {
+    // Default port in use - offer to change to available port
+    console.log("ERROR: Port " + port + " in use - do you have another prototype running?\n");
+    // Set up prompt settings
+    prompt.colors = false;
+    prompt.start();
+    prompt.message = "";
+    prompt.delimiter = "";
+
+    // Ask user if they want to change port
+    prompt.get([{
+      name: 'answer',
+      description: 'Change to an available port? (y/n)',
+      required: true,
+      type: 'string',
+      pattern: /y(es)?|no?/i,
+      message: 'Please enter y or n'
+    }], function (err, result) {
+      if (result.answer.match(/y(es)?/i) ) {
+        // User answers yes
+        port = availablePort;
+        app.listen(port);
+        console.log('Changed to port ' + port + '   url: http://localhost:' + port);
+      }
+      else {
+        // User answers no - exit
+        console.log('You can set a new default port in server.js, or by running the server with PORT=XXXX');
+        console.log("Exiting");
+        process.exit(0);
+      }
+    });
+  }
+});
+


### PR DESCRIPTION
*from Ed's original PR:*

This pull request improves how we handle port in use errors.

Changes:
* Check if the default port is in use. If free, start the app.
* If port is in use, ask user if they want to change to a new port.

Reasoning for not changing to a new port by default:
Unless the user spots the issue, going to the browser doesn't help. Either way we need them to look at the terminal. This makes the issue more explicit - and may help them go about changing the default port for the prototype.