### PR TITLE
Use npm start as the standard way to run the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This will install extra code that the prototype kit needs.
 #### Run the app
 
 ```
-node start.js
+npm start
 ```
 
 Go to [localhost:3000](http://localhost:3000) in your browser.
@@ -55,7 +55,7 @@ Go to [localhost:3000](http://localhost:3000) in your browser.
 If you want to view multiple prototypes at the same time you can give them unique port numbers, like this:
 
 ```
-PORT=3005 node start.js
+PORT=3005 npm start
 ```
 
 To avoid conflicts we recommend using ports between 3000 and 3009. To change the port number permanently, edit the port variable in /server.js.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "engines": {
     "node": "4.x"
   },
+  "scripts": {
+    "start": "node start.js"
+  },
   "dependencies": {
     "basic-auth": "^1.0.3",
     "body-parser": "^1.14.1",


### PR DESCRIPTION
I got caught out when running a prototype app as I expected `npm start` to work - but `start` defaults to running `server.js`.

This project has a `server.js`, so there's no error - but the grunt part is skipped and the asset build never runs.

I figure it should be safe to add this config into the `package.json` so no-one gets caught out by this in the future - the existing `node start.js` still works as before.