### PR TITLE
Improve docs for case where there are multiple remotes

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -29,10 +29,15 @@ heroku config:set USERNAME=username_here
 heroku config:set PASSWORD=password_here
 ```
 If you don't want to have password protection on your prototype, you can set the `USE_AUTH` config var:
+
 ```
 heroku config:set USE_AUTH=false
 ```
-If you have more than one remote you'll need to add a flag `-r 'remote_name'` to specifiy which remote to set. Eg `heroku config:set PASSWORD=password_here -r dev`.
+If you have more than one remote you'll need to add a flag `-r 'remote_name'` to specifiy which remote to set.
+
+```
+heroku config:set PASSWORD=password_here -r dev
+```
 
 ### 4) Deploy changes
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -33,10 +33,10 @@ If you don't want to have password protection on your prototype, you can set the
 ```
 heroku config:set USE_AUTH=false
 ```
-If you have more than one remote you'll need to add a flag `-r 'remote_name'` to specifiy which remote to set.
+If you have more than one remote you'll need to add a flag to specifiy which remote to set.
 
 ```
-heroku config:set PASSWORD=password_here -r dev
+heroku config:set PASSWORD=password_here -r remotename_here
 ```
 
 ### 4) Deploy changes

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -33,7 +33,7 @@ If you don't want to have password protection on your prototype, you can set the
 ```
 heroku config:set USE_AUTH=false
 ```
-If you have more than one remote you'll need to add a flag to specifiy which remote to set.
+If you have more than one remote you'll need to add a flag to specify which remote to set.
 
 ```
 heroku config:set PASSWORD=password_here -r remotename_here

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -22,17 +22,18 @@ However, the kit won't show your prototype online without setting a username and
 
 ### 3) Set a username and password
 
-You can do this in the Heroku admin console (under Settings ▶ Config Variables) or by running the following commands:
+You can do this in the on the Heroku website (under Settings ▶ Config Variables) or by running the following commands:
 
 ```
 heroku config:set USERNAME=username_here
 heroku config:set PASSWORD=password_here
 ```
-
 If you don't want to have password protection on your prototype, you can set the `USE_AUTH` config var:
 ```
 heroku config:set USE_AUTH=false
 ```
+If you have more than one remote you'll need to add a flag `-r 'remote_name'` to specifiy which remote to set. Eg `heroku config:set PASSWORD=password_here -r dev`.
+
 ### 4) Deploy changes
 
 If you make a change to your prototype, commit your changes as usual then run:


### PR DESCRIPTION
This improves the docs for the case where a user has more than one heroku remote and will need to specify it when setting config vars.

Fixes #110