### PR TITLE
Use Travis to deploy master to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ script:
   - ./node_modules/grunt-cli/bin/grunt test
   # If the app runs, check to see if the version file has been updated
   - ./create-release-tag.sh
+deploy:
+  provider: heroku
+  api_key:
+    secure: h/9/Rcd41XVU4VYYeBoKKvG6uShEoDksCGGZ/2dgeY1f3tYnhGzzgL6TIkvhafwDbKk2Y4o6d/MI05K+s7lorf2uTKpr1To2o52hQqmb4YREPWruZtBqoRo5X4nCeN2oEdW+yJRH3jZDNUmwkPzjytqxkcUUUeDPHfz3+xCtSZk=
+  app: govuk-prototype-kit
+  on: master
 
 notifications:
   email: false


### PR DESCRIPTION
Automatically deploy the app to Heroku using Travis after a successful
build.

cc. @timpaul, @tombye, @joelanman.