### PR TITLE
Improve accessibility for the example question page

### DIFF
--- a/app/views/examples/question-page.html
+++ b/app/views/examples/question-page.html
@@ -34,7 +34,7 @@
 
             <div class="form-group form-group-year">
               <label for="dob-year">Year</label>
-              <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
+              <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="1910" max="2014">
             </div>
 
           </div>

--- a/app/views/examples/question-page.html
+++ b/app/views/examples/question-page.html
@@ -20,11 +20,11 @@
           <legend class="visuallyhidden">Date of birth</legend>
           <div class="form-date">
 
-            <p class="form-hint">For example, 31 3 1980</p>
+            <p class="form-hint" id="dob-hint">For example, 31 3 1980</p>
 
             <div class="form-group form-group-day">
               <label for="dob-day">Day</label>
-              <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+              <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
             </div>
 
             <div class="form-group form-group-month">


### PR DESCRIPTION
This PR includes the recommendations from Léonie to create an association between the form hint and the form fields and use a more realistic field range for year of birth


#### Hints.

The hints provided for some fields are not programmatically associated with
their form fields. This means that as a screen reader user tabs through the
form, the hint information is not automatically announced. For example:

```
<p class="form-hint">For example, 31 3 1980</p>
...
<label for="dob-day">Day</label>
<input class="form-control" type="number" max="31" min="0" pattern="[0-9]*" name="dob-day"
id="dob-day">
```

Recommend using `aria-describedby` to create the association. This will cause
screen readers to announce the hint (after they announce the legend and/or
form label for the field). 

For example:

```
<p id="dobHint" class="form-hint">For example, 31 3 1980</p>
...
<label for="dob-day">Day</label>
<input type="number" max="31" min="0" pattern="[0-9]*" name="dob-day"
id="dob-day" class="form-control" aria-describedby="dobHint">
```

#### Field range.

The range for the DOB year is 0 to 2014. For someone using a keyboard to
spin through the range this equates to a lot of key presses. It is possible
to type a number directly into the field, but even so the extent of this
range seems too much.

Recommend using a more realistic range (especially for a DOB), perhaps 1910
to 2014.