### PR TITLE
Add phase banner includes

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -15,10 +15,17 @@
 // If you need a phase banner, put this inside the main content area
 // See elements _layout.scss line 22.
 .phase-banner-alpha  {
-  @include phase-banner(alpha); // Change this to (beta) for a beta banner
+  @include phase-banner(alpha);
 }
 .phase-tag-alpha {
-  @include phase-tag(alpha); // Change this to (beta) for a beta tag
+  @include phase-tag(alpha);
+}
+
+.phase-banner-beta {
+  @include phase-banner(beta);
+}
+.phase-tag-beta {
+  @include phase-tag(beta);
 }
 
 // If you need to create a page as part of your journey, but without GOV.UK branding

--- a/app/views/includes/phase_banner_alpha.html
+++ b/app/views/includes/phase_banner_alpha.html
@@ -1,0 +1,6 @@
+<div class="phase-banner-alpha">
+  <p>
+    <strong class="phase-tag">ALPHA</strong>
+    <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+  </p>
+</div>

--- a/app/views/includes/phase_banner_beta.html
+++ b/app/views/includes/phase_banner_beta.html
@@ -1,0 +1,6 @@
+<div class="phase-banner-beta">
+  <p>
+    <strong class="phase-tag">BETA</strong>
+    <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+  </p>
+</div>


### PR DESCRIPTION
This PR adds two new includes for the alpha and beta phase banners, [using the snippets provided as examples by govuk elements, seen here](http://govuk-elements.herokuapp.com/alpha-beta-banners/).

![alpha and beta banners gov uk elements](https://cloud.githubusercontent.com/assets/417754/12265052/c2393b6e-b932-11e5-883e-ed15fe9c71b7.png)
