### PR TITLE
Create config file that stores prototype configuration

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,0 +1,16 @@
+// Use this file to change prototype configuration.
+
+// Note: prototype config can be overridden using environment variables (eg on heroku)
+
+module.exports = {
+
+  // Service name used in header. Eg: 'Renew your passport'
+  serviceName: 'Set service name in app/config.js',
+
+  // Default port that prototype runs on
+  port: '3000',
+
+  // Enable or disable password protection on production
+  useAuth: 'true'
+
+};

--- a/app/config.js
+++ b/app/config.js
@@ -5,7 +5,7 @@
 module.exports = {
 
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Set service name in app/config.js',
+  serviceName: "Set service name in /app/config.js",
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/config.js
+++ b/app/config.js
@@ -5,7 +5,7 @@
 module.exports = {
 
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: "Set service name in /app/config.js",
+  serviceName: "Service name goes here",
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/includes/propositional_navigation.html
+++ b/app/views/includes/propositional_navigation.html
@@ -2,7 +2,7 @@
   <div class="content">
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
     <nav id="proposition-menu">
-      <a href="/" id="proposition-name">{{serviceName}}</a>
+      <a href="/" id="proposition-name">{{$serviceName}}{{serviceName}}{{/serviceName}}</a>
       <!--
       <ul id="proposition-links">
         <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>

--- a/app/views/includes/propositional_navigation.html
+++ b/app/views/includes/propositional_navigation.html
@@ -2,7 +2,7 @@
   <div class="content">
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
     <nav id="proposition-menu">
-      <a href="/" id="proposition-name">Service name</a>
+      <a href="/" id="proposition-name">{{serviceName}}</a>
       <!--
       <ul id="proposition-links">
         <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -24,6 +24,7 @@
 
       <p>We recommend you add links to your prototype to this page, rather than delete it.
         You'll find this page in the kit at '/app/views/index.html'.</p>
+      <p>You can change the service name by editing the file '/app/config.js'.</p>
 
 
       <h2 class="heading-medium">Examples and documentation</h2>

--- a/server.js
+++ b/server.js
@@ -5,14 +5,15 @@ var path  = require('path'),
     app = express(),
     basicAuth = require('basic-auth'),
     bodyParser = require('body-parser'),
-    port = (process.env.PORT || 3000),
+    config = require(__dirname + '/app/config.js'),
+    port = (process.env.PORT || config.port),
     utils = require(__dirname + '/lib/utils.js'),
 
 // Grab environment variables specified in Procfile or as Heroku config vars
     username = process.env.USERNAME,
     password = process.env.PASSWORD,
     env      = process.env.NODE_ENV || 'development',
-    useAuth  = process.env.USE_AUTH || 'true';
+    useAuth  = process.env.USE_AUTH || config.useAuth;
 
     env      = env.toLowerCase();
     useAuth  = useAuth.toLowerCase();
@@ -47,6 +48,12 @@ app.use(bodyParser.urlencoded({
 // send assetPath to all views
 app.use(function (req, res, next) {
   res.locals.assetPath="/public/";
+  next();
+});
+
+// Add variables that are available in all views
+app.use(function (req, res, next) {
+  res.locals.serviceName=config.serviceName;
   next();
 });
 


### PR DESCRIPTION
Copied from #97:

This PR creates a new config.js file for storing configuration that users may want to edit.

Currently, users can edit:

Service name - used in the header
Port
Whether auth is enabled or not.
NB - I've not mentioned the config file in any docs - not sure where it would go. However, the default service name points the user at the location of the file to edit.