### PR TITLE
Making nunjucks a little more forgiving.

### DIFF
--- a/app/views/404.html
+++ b/app/views/404.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+	Access To Work - Prototype
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+<h1 class="heading-large">404</h1>
+
+<p><span style="color:#005EA5">{{ path }}</span> was not found</p>
+
+<div style="font-family:courier;font-size:14px;padding:15px;background:#ccc">
+  <p style="margin-top:0">{{ errors[0] }}</p>
+  <p style="margin:0">{{ errors[1] }}</p>
+</div>
+
+</main>
+
+{% endblock %}
+

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-	Access To Work - Prototype
+	
 {% endblock %}
 
 {% block content %}
@@ -20,4 +20,3 @@
 </main>
 
 {% endblock %}
-

--- a/lib/default-routes.js
+++ b/lib/default-routes.js
@@ -1,0 +1,56 @@
+var express     = require('express'),
+    fs          = require("fs"),
+    merge       = require('merge'),
+    router      = express.Router();
+    
+/*
+  Main route that maps the URL onto your /app/views/ folder 
+  and sees whether you have a .html template waiting there 
+  to use. If there's no template it checks whether the URL 
+  maps to a folder with a index.html in it. Otherwise it 
+  renders a 404 with an error message.
+*/
+router.get(/^\/([^.]+)$/, function (req, res) {
+
+  var path = (req.params[0]);
+
+  // remove the trailing slash because it seems nunjucks doesn't expect it.
+  if (path.substr(-1) === '/') path = path.substr(0, path.length - 1);
+
+  // try and render the path – it gets '.html' added 
+  // to it and searches in your "app/views/" folder.
+  res.render(path, merge(true, req.cookies, req.data), function(err, html)
+  {
+    // if it errors try seeing whether it's a folder 
+    // name and look for an index.html file inside it.
+    if (err) 
+    {
+      res.render(path + "/index", merge(true, req.cookies, req.data), function(err2, html) 
+      {
+        if (err2) {
+          // no, nothing exists anywhere for this route. 404!
+          res.status(404);
+          res.render("404", {"path":path,"errors":[err,err2]}, function(err3, html)
+          {
+            if (err3) res.status(404).send('404 Not Found');
+            else res.end(html);
+          });          
+          // res.status(404).send('<b>'+path+' - not found</b><br />'+err+'<br />'+err2);
+        } else {
+          // it was a folder name.
+          res.end(html);
+        }
+      });
+    } else {
+      // it was an html file.
+      res.end(html);
+    }
+  });
+});
+
+router.post(/^\/([^.]+)$/, function (req, res) {
+  var path = (req.params[0]);
+  res.redirect('/'+path);
+});
+
+module.exports = router;

--- a/lib/default-routes.js
+++ b/lib/default-routes.js
@@ -47,9 +47,4 @@ router.get(/^\/([^.]+)$/, function (req, res) {
   });
 });
 
-router.post(/^\/([^.]+)$/, function (req, res) {
-  var path = (req.params[0]);
-  res.redirect('/'+path);
-});
-
 module.exports = router;

--- a/lib/default-routes.js
+++ b/lib/default-routes.js
@@ -1,13 +1,12 @@
 var express     = require('express'),
     fs          = require("fs"),
-    merge       = require('merge'),
     router      = express.Router();
-    
+
 /*
-  Main route that maps the URL onto your /app/views/ folder 
-  and sees whether you have a .html template waiting there 
-  to use. If there's no template it checks whether the URL 
-  maps to a folder with a index.html in it. Otherwise it 
+  Main route that maps the URL onto your /app/views/ folder
+  and sees whether you have a .html template waiting there
+  to use. If there's no template it checks whether the URL
+  maps to a folder with a index.html in it. Otherwise it
   renders a 404 with an error message.
 */
 router.get(/^\/([^.]+)$/, function (req, res) {
@@ -17,15 +16,15 @@ router.get(/^\/([^.]+)$/, function (req, res) {
   // remove the trailing slash because it seems nunjucks doesn't expect it.
   if (path.substr(-1) === '/') path = path.substr(0, path.length - 1);
 
-  // try and render the path – it gets '.html' added 
+  // try and render the path – it gets '.html' added
   // to it and searches in your "app/views/" folder.
-  res.render(path, merge(true, req.cookies, req.data), function(err, html)
+  res.render(path, function(err, html)
   {
-    // if it errors try seeing whether it's a folder 
+    // if it errors try seeing whether it's a folder
     // name and look for an index.html file inside it.
-    if (err) 
+    if (err)
     {
-      res.render(path + "/index", merge(true, req.cookies, req.data), function(err2, html) 
+      res.render(path + "/index", function(err2, html)
       {
         if (err2) {
           // no, nothing exists anywhere for this route. 404!
@@ -34,7 +33,7 @@ router.get(/^\/([^.]+)$/, function (req, res) {
           {
             if (err3) res.status(404).send('404 Not Found');
             else res.end(html);
-          });          
+          });
           // res.status(404).send('<b>'+path+' - not found</b><br />'+err+'<br />'+err2);
         } else {
           // it was a folder name.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "hogan.js": "3.0.2",
     "minimist": "0.0.8",
     "readdir": "0.0.6",
-    "serve-favicon": "2.3.0",
-    "merge": "^1.2.0"
+    "serve-favicon": "2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "hogan.js": "3.0.2",
     "minimist": "0.0.8",
     "readdir": "0.0.6",
-    "serve-favicon": "2.3.0"
+    "serve-favicon": "2.3.0",
+    "merge": "^1.2.0"
   }
 }


### PR DESCRIPTION
I've been trying to implement nunjucks on my prototype recently and so I've put this PR together with a few little changes which I found made it easier to use.

Basically the main thing is I've expanded the default catch-all route (and moved it into it's own file) so that it's a bit clearer and so that now if it doesn't find the correct template it spits out it's errors into a 404 page (included in /app/views/) which will hopefully point people in the right direction sorting the problem.