### PR TITLE
Bump the govuk frontend toolkit to 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
-    "govuk_frontend_toolkit": "^4.2.1",
+    "govuk_frontend_toolkit": "^4.6.0",
     "govuk_template_mustache": "^0.16.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
The changes to govuk elements in #124, require the the most recent version of the govuk frontend toolkit - as the breadcrumb styles were moved to a new mixin in `design-patterns/breadcrumbs`.


From the GOV.UK frontend toolkit's changelog.

# 4.6.0

- Add breadcrumb styles, separator images and documentation (PR #236)
- Add fallback image for the back link (PR #235)

# 4.5.0

- Find and auto-start JavaScript modules from markup:
`data-module="module-name"`(PR #227)

# 4.4.0

- Add helpers partial for functions
- Add px to em function and documentation

# 4.3.0

- Allow javascript error tracking to be filtered to avoid noise from
plugins