### PR TITLE
Adds tmuxp config files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 public
 govuk_modules
 node_modules/*
+.tmuxp.*


### PR DESCRIPTION
For those that might be using [tmuxp](http://tmuxp.readthedocs.org/en/latest/) and want to include the config dotfile in the project directory. 