### PR TITLE
Fix warning for npm engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "private": true,
   "engines": {
-    "node": "4.x"
+    "node": ">=4.0 <5.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
This allows any version of node greater than, or 4.0.0

This fixes #139.