### PR TITLE
Add phase_banner block to layout

### DIFF
--- a/app/views/examples/blank-govuk.html
+++ b/app/views/examples/blank-govuk.html
@@ -6,7 +6,4 @@
 
 {% block content %}
 
-<main id="content" role="main">
-</main>
-
 {% endblock %}

--- a/app/views/examples/blank-unbranded.html
+++ b/app/views/examples/blank-unbranded.html
@@ -6,15 +6,11 @@
 
 {% block content %}
 
-<main id="content" role="main">
-
-  <h1 class="heading-xlarge">
-    Example without GOV.UK branding
-  </h1>
-  <p class="lede">
-    This page doesn't use New Transport or display the GOV.UK header and footer.
-  </p>
-
-</main>
+<h1 class="heading-xlarge">
+  Example without GOV.UK branding
+</h1>
+<p class="lede">
+  This page doesn't use New Transport or display the GOV.UK header and footer.
+</p>
 
 {% endblock %}

--- a/app/views/examples/check-your-answers-page.html
+++ b/app/views/examples/check-your-answers-page.html
@@ -6,128 +6,124 @@
 
 {% block content %}
 
-<main id="content" role="main">
+<h1 class="heading-large">
+  Check your answers before sending your application
+</h1>
 
-  <h1 class="heading-large">
-    Check your answers before sending your application
-  </h1>
+<table class="check-your-answers">
 
-  <table class="check-your-answers">
+  <thead>
+    <tr>
+      <th colspan="2">
+        <h2 class="heading-medium">
+          Organisations involved
+        </h2>
+      </th>
+      <th>
+      </th>
+    </tr>
+  </thead>
 
-    <thead>
-      <tr>
-        <th colspan="2">
-          <h2 class="heading-medium">
-            Organisations involved
-          </h2>
-        </th>
-        <th>
-        </th>
-      </tr>
-    </thead>
+  <tbody>
+    <tr>
+      <td>
+        Exporter
+      </td>
+      <td>
+        Exporter name<br>
+        First line of address<br>
+        Second line of address<br>
+        Contact: Contact Name<br>
+        Tel: 01234 567 890<br>
+        Email: email@email.com
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Exporter name</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Producer
+      </td>
+      <td>
+        Producer name
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Producer name</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Site of export
+      </td>
+      <td>
+        Site of export name
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Site of export name</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Importer
+      </td>
+      <td>
+        Importer name<br>
+        First line of address<br>
+        Second line of address<br>
+        Contact: Contact Name<br>
+        Tel: 01234 567 890<br>
+        Email: email@email.com
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Importer name</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Recovery facilities
+      </td>
+      <td>
+        Recovery facilities name
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Recovery facilities name</span>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Recovery site
+      </td>
+      <td>
+        Recovery site name
+      </td>
+      <td class="change-answer">
+        <a href="#">
+          Change <span class="visuallyhidden">Recovery site name</span>
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-    <tbody>
-      <tr>
-        <td>
-          Exporter
-        </td>
-        <td>
-          Exporter name<br>
-          First line of address<br>
-          Second line of address<br>
-          Contact: Contact Name<br>
-          Tel: 01234 567 890<br>
-          Email: email@email.com
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Exporter name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Producer
-        </td>
-        <td>
-          Producer name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Producer name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Site of export
-        </td>
-        <td>
-          Site of export name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Site of export name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Importer
-        </td>
-        <td>
-          Importer name<br>
-          First line of address<br>
-          Second line of address<br>
-          Contact: Contact Name<br>
-          Tel: 01234 567 890<br>
-          Email: email@email.com
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Importer name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Recovery facilities
-        </td>
-        <td>
-          Recovery facilities name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Recovery facilities name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Recovery site
-        </td>
-        <td>
-          Recovery site name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Recovery site name</span>
-          </a>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+<h2 class="heading-medium">Now send your application</h2>
 
-  <h2 class="heading-medium">Now send your application</h2>
+<p class="text">
+  By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
+</p>
 
-  <p class="text">
-    By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
-  </p>
-
-  <div class="form-group">
-    <a href="confirmation-page" class="button">Accept and send application</a>
-  </div>
-
-</main>
+<div class="form-group">
+  <a href="confirmation-page" class="button">Accept and send application</a>
+</div>
 
 {% endblock %}

--- a/app/views/examples/confirmation-page.html
+++ b/app/views/examples/confirmation-page.html
@@ -6,29 +6,25 @@
 
 {% block content %}
 
-<main id="content" role="main">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-
-      <div class="govuk-box-highlight">
-        <h1 class="bold-large">Application complete</h1>
-        <p>
-          Your reference number is <br>
-          <strong class="heading-medium">HDJ2123F</strong>
-        </p>
-      </div>
-      <p>We have sent you a confirmation email.</p>
-
-      <h2 class="heading-medium">What happens next</h2>
-      <p>We've sent your application to Hackney Electoral Register Office.</p>
-      <p>They will contact you either to confirm your registration, or to ask for more information.</p>
-      <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
-
-
+    <div class="govuk-box-highlight">
+      <h1 class="bold-large">Application complete</h1>
+      <p>
+        Your reference number is <br>
+        <strong class="heading-medium">HDJ2123F</strong>
+      </p>
     </div>
-  </div>
+    <p>We have sent you a confirmation email.</p>
 
-</main>
+    <h2 class="heading-medium">What happens next</h2>
+    <p>We've sent your application to Hackney Electoral Register Office.</p>
+    <p>They will contact you either to confirm your registration, or to ask for more information.</p>
+    <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
+
+
+  </div>
+</div>
 
 {% endblock %}

--- a/app/views/examples/elements/forms.html
+++ b/app/views/examples/elements/forms.html
@@ -5,83 +5,81 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
 
-  <form action="/" method="post" class="form">
+<form action="/" method="post" class="form">
 
-    <h1 class="form-title heading-large">
-      Your details
-    </h1>
+  <h1 class="form-title heading-large">
+    Your details
+  </h1>
 
-    <!-- Full name -->
-    <div class="form-group">
-      <label class="form-label-bold" for="full-name">Full name</label>
-      <p class="form-hint">As shown on your birth certificate or passport</p>
-      <input type="text" class="form-control" id="full-name">
-    </div>
+  <!-- Full name -->
+  <div class="form-group">
+    <label class="form-label-bold" for="full-name">Full name</label>
+    <p class="form-hint">As shown on your birth certificate or passport</p>
+    <input type="text" class="form-control" id="full-name">
+  </div>
 
-    <!-- National Insurance number -->
-    <div class="form-group">
-      <label class="form-label-bold" for="ni-number">
-        National Insurance number
-        <span class="form-hint">
-          It's on your National Insurance card, benefit letter, payslip or P60.
-          <br>
-          For example, 'VO 12 34 56 D'.
-        </span>
-      </label>
-      <input type="text" class="form-control" id="ni-number">
-    </div>
+  <!-- National Insurance number -->
+  <div class="form-group">
+    <label class="form-label-bold" for="ni-number">
+      National Insurance number
+      <span class="form-hint">
+        It's on your National Insurance card, benefit letter, payslip or P60.
+        <br>
+        For example, 'VO 12 34 56 D'.
+      </span>
+    </label>
+    <input type="text" class="form-control" id="ni-number">
+  </div>
 
-    <!-- Date of birth -->
-    <div class="form-group">
-      <fieldset>
-        <legend class="form-label-bold">Date of birth</legend>
+  <!-- Date of birth -->
+  <div class="form-group">
+    <fieldset>
+      <legend class="form-label-bold">Date of birth</legend>
 
-        <div class="form-date">
+      <div class="form-date">
 
-          <p class="form-hint">For example, 31 3 1980</p>
+        <p class="form-hint">For example, 31 3 1980</p>
 
-          <div class="form-group form-group-day">
-            <label for="dob-day">Day</label>
-            <input class="form-control" id="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
-          </div>
-
-          <div class="form-group form-group-month">
-            <label for="dob-month">Month</label>
-            <input class="form-control" id="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
-          </div>
-
-          <div class="form-group form-group-year">
-            <label for="dob-year">Year</label>
-            <input class="form-control" id="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
-          </div>
+        <div class="form-group form-group-day">
+          <label for="dob-day">Day</label>
+          <input class="form-control" id="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
         </div>
 
-      </fieldset>
-    </div>
-
-    <div class="form-group">
-      <details>
-        <summary><span class="summary">Help with date of birth</span></summary>
-        <div class="panel panel-border-narrow">
-          <p>
-            If you don’t know your exact date of birth, use the one you put on official documents (for example, your passport or driving licence).
-          </p>
-          <p>
-            If you can’t provide your date of birth you’ll have to send copies of identity documents through the post.
-          </p>
+        <div class="form-group form-group-month">
+          <label for="dob-month">Month</label>
+          <input class="form-control" id="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
         </div>
-      </details>
-    </div>
 
-    <div class="form-group">
-      <input type="submit" class="button" value="Continue">
-    </div>
+        <div class="form-group form-group-year">
+          <label for="dob-year">Year</label>
+          <input class="form-control" id="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
+        </div>
+      </div>
 
-  </form>
+    </fieldset>
+  </div>
 
-</main>
+  <div class="form-group">
+    <details>
+      <summary><span class="summary">Help with date of birth</span></summary>
+      <div class="panel panel-border-narrow">
+        <p>
+          If you don’t know your exact date of birth, use the one you put on official documents (for example, your passport or driving licence).
+        </p>
+        <p>
+          If you can’t provide your date of birth you’ll have to send copies of identity documents through the post.
+        </p>
+      </div>
+    </details>
+  </div>
+
+  <div class="form-group">
+    <input type="submit" class="button" value="Continue">
+  </div>
+
+</form>
+
 {% endblock %}

--- a/app/views/examples/elements/grid-layout.html
+++ b/app/views/examples/elements/grid-layout.html
@@ -5,117 +5,115 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
 
-  <h1 class="heading-xlarge">
-    New grid layout example
-  </h1>
+<h1 class="heading-xlarge">
+  New grid layout example
+</h1>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h2 class="bold-medium">Two thirds</h2>
-      <div class="text">
-        <p>
-          The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-        </p>
-        <p>
-          The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-        </p>
-      </div>
-    </div>
-    <div class="column-third">
-      <h2 class="bold-medium">One third</h2>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h2 class="bold-medium">Two thirds</h2>
+    <div class="text">
+      <p>
+        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+      </p>
       <p>
         The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
       </p>
     </div>
   </div>
-
-  <div class="grid-row">
-    <div class="column-third">
-      <h2 class="bold-medium">One third</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
-      </p>
-    </div>
-    <div class="column-third">
-      <h2 class="bold-medium">One third</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
-      </p>
-    </div>
-    <div class="column-third">
-      <h2 class="bold-medium">One third</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
-      </p>
-    </div>
+  <div class="column-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
   </div>
+</div>
 
-  <div class="grid-row">
-    <div class="column-half">
-      <h2 class="bold-medium">One half</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-half">
-      <h2 class="bold-medium">One half</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
+<div class="grid-row">
+  <div class="column-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
+    </p>
   </div>
-
-  <div class="grid-row">
-    <div class="column-half">
-      <h2 class="bold-medium">One half</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
+  <div class="column-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
+    </p>
   </div>
-
-  <div class="grid-row">
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
-    <div class="column-quarter">
-      <h2 class="bold-medium">One quarter</h2>
-      <p>
-        The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
-      </p>
-    </div>
+  <div class="column-third">
+    <h2 class="bold-medium">One third</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government.
+    </p>
   </div>
+</div>
 
-</main>
+<div class="grid-row">
+  <div class="column-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-half">
+    <h2 class="bold-medium">One half</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+  <div class="column-quarter">
+    <h2 class="bold-medium">One quarter</h2>
+    <p>
+      The Deputy Prime Minister, Nick Clegg MP, is the deputy head of government. He is the leader of the Liberal Democrats and was appointed Deputy Prime Minister when the coalition government was formed following the 2010 general election.
+    </p>
+  </div>
+</div>
+
 {% endblock %}

--- a/app/views/examples/elements/radio-buttons-checkboxes.html
+++ b/app/views/examples/elements/radio-buttons-checkboxes.html
@@ -5,97 +5,96 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-      <form action="/" method="post" class="form">
+    <form action="/" method="post" class="form">
 
-        <h1 class="heading-xlarge">
-          Radio buttons <br> and checkboxes
-        </h1>
+      <h1 class="heading-xlarge">
+        Radio buttons <br> and checkboxes
+      </h1>
 
-        <p>
-          This test page demonstrates selection-buttons.js from the govuk frontend toolkit, which
-          sets 'focused' and 'selected' states for the large hit area labels that wrap checkboxes and radio buttons.
-        </p>
+      <p>
+        This test page demonstrates selection-buttons.js from the govuk frontend toolkit, which
+        sets 'focused' and 'selected' states for the large hit area labels that wrap checkboxes and radio buttons.
+      </p>
 
-        <p>
-          It also demonstrates setting ARIA attributes when showing and hiding additional content.
-        </p>
+      <p>
+        It also demonstrates setting ARIA attributes when showing and hiding additional content.
+      </p>
 
-        <h2 class="heading-large">
-          What is your nationality?
-        </h2>
+      <h2 class="heading-large">
+        What is your nationality?
+      </h2>
 
-        <p>If you have dual nationality, select all options that are relevant to you.</p>
+      <p>If you have dual nationality, select all options that are relevant to you.</p>
 
-        <div class="form-group">
-          <fieldset>
+      <div class="form-group">
+        <fieldset>
 
-            <legend class="visuallyhidden">What is your nationality?</legend>
+          <legend class="visuallyhidden">What is your nationality?</legend>
 
-            <label for="nationality_british" class="block-label">
-              <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
-              British
+          <label for="nationality_british" class="block-label">
+            <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
+            British
+          </label>
+
+          <label for="nationality_irish" class="block-label">
+            <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
+            Irish
+          </label>
+
+          <label for="nationality_other" class="block-label" data-target="example_nationality_other">
+            <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
+            Citizen of another country
+          </label>
+
+          <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
+            <label for="nationality_other_countries" class="form-label">
+              Country name
             </label>
+            <input class="form-control" type="text" id="nationality_other_countries">
+          </div>
 
-            <label for="nationality_irish" class="block-label">
-              <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
-              Irish
-            </label>
+        </fieldset>
+      </div>
 
-            <label for="nationality_other" class="block-label" data-target="example_nationality_other">
-              <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
-              Citizen of another country
-            </label>
+      <h2 class="heading-large">
+        Which part of the Housing Act was your licence isued under?
+      </h2>
 
-            <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
-              <label for="nationality_other_countries" class="form-label">
-                Country name
-              </label>
-              <input class="form-control" type="text" id="nationality_other_countries">
-            </div>
+      <p>
+        Select one of the options below.
+      </p>
 
-          </fieldset>
-        </div>
+      <div class="form-group">
+        <fieldset>
 
-        <h2 class="heading-large">
-          Which part of the Housing Act was your licence isued under?
-        </h2>
+          <legend class="visuallyhidden">
+            Which part of the Housing Act was your licence isued under?
+          </legend>
 
-        <p>
-          Select one of the options below.
-        </p>
+          <label for="radio-part-2" class="block-label">
+            <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
+            <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
+            For properties that are 3 or more stories high and occupied by 5 or more people
+          </label>
 
-        <div class="form-group">
-          <fieldset>
+          <label for="radio-part-3" class="block-label">
+            <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
+            <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
+            For properties that are within a geographical area defined by a local council
+          </label>
 
-            <legend class="visuallyhidden">
-              Which part of the Housing Act was your licence isued under?
-            </legend>
+        </fieldset>
+      </div>
 
-            <label for="radio-part-2" class="block-label">
-              <input id="radio-part-2" type="radio" name="housing-act" value="Part 2">
-              <span class="heading-small">Part 2 of the Housing Act 2004</span><br>
-              For properties that are 3 or more stories high and occupied by 5 or more people
-            </label>
+    </form>
 
-            <label for="radio-part-3" class="block-label">
-              <input id="radio-part-3" type="radio" name="housing-act" value="Part 3">
-              <span class="heading-small">Part 3 of the Housing Act 2004</span><br>
-              For properties that are within a geographical area defined by a local council
-            </label>
-
-          </fieldset>
-        </div>
-
-      </form>
-
-    </div>
   </div>
-</main>
+</div>
+
 {% endblock %}

--- a/app/views/examples/elements/toggled-content.html
+++ b/app/views/examples/elements/toggled-content.html
@@ -5,115 +5,114 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-      <form action="/" method="post" class="form">
+    <form action="/" method="post" class="form">
 
-        <h1 class="heading-xlarge">
-          Toggled content
-        </h1>
+      <h1 class="heading-xlarge">
+        Toggled content
+      </h1>
 
-        <p>
-          This page shows how to use the <code class="code">data-target</code> attribute to show and hide content when a radio button or checkbox is selected.
-        </p>
+      <p>
+        This page shows how to use the <code class="code">data-target</code> attribute to show and hide content when a radio button or checkbox is selected.
+      </p>
 
-        <div class="form-group">
-          <fieldset>
+      <div class="form-group">
+        <fieldset>
 
-            <legend class="visuallyhidden">What is your nationality?</legend>
+          <legend class="visuallyhidden">What is your nationality?</legend>
 
-            <label class="block-label" for="nationality_british">
-              <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
-              British
+          <label class="block-label" for="nationality_british">
+            <input type="checkbox" name="nationality_british" value="British" id="nationality_british">
+            British
+          </label>
+
+          <label class="block-label" for="nationality_irish">
+            <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
+            Irish
+          </label>
+
+          <label class="block-label" for="nationality_other" data-target="example_nationality_other">
+            <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
+            Citizen of another country
+          </label>
+
+          <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
+            <label class="form-label" for="nationality_other_countries">
+              Country name
             </label>
+            <input class="form-control" type="text" id="nationality_other_countries">
+          </div>
 
-            <label class="block-label" for="nationality_irish">
-              <input type="checkbox" name="nationality_irish" value="Irish" id="nationality_irish">
-              Irish
-            </label>
+        </fieldset>
+      </div>
 
-            <label class="block-label" for="nationality_other" data-target="example_nationality_other">
-              <input type="checkbox" name="nationality_other" value="Wales" id="nationality_other">
-              Citizen of another country
-            </label>
+      <h1 class="heading-large">
+        Where should we send your new<br> passport?
+      </h1>
 
-            <div class="panel panel-border-narrow js-hidden" id="example_nationality_other">
-              <label class="form-label" for="nationality_other_countries">
-                Country name
-              </label>
-              <input class="form-control" type="text" id="nationality_other_countries">
-            </div>
+      <div class="form-group">
+        <fieldset>
 
-          </fieldset>
-        </div>
+          <legend class="visuallyhidden">
+            Where should we send your new passport?
+          </legend>
 
-        <h1 class="heading-large">
-          Where should we send your new<br> passport?
-        </h1>
+          <label class="block-label" for="radio-home-address" >
+            <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
+            Home address
+          </label>
 
-        <div class="form-group">
-          <fieldset>
+          <label class="block-label" for="radio-other-address" data-target="example-other-address">
+            <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
+            Other address
+          </label>
 
-            <legend class="visuallyhidden">
-              Where should we send your new passport?
-            </legend>
+          <div class="panel panel-border-narrow js-hidden" id="example-other-address">
 
-            <label class="block-label" for="radio-home-address" >
-              <input id="radio-home-address" type="radio" name="radio-indent-group" value="Yes">
-              Home address
-            </label>
+            <h2 class="heading-medium">
+              Your other address
+            </h2>
 
-            <label class="block-label" for="radio-other-address" data-target="example-other-address">
-              <input id="radio-other-address" type="radio" name="radio-indent-group" value="No">
-              Other address
-            </label>
+            <fieldset>
 
-            <div class="panel panel-border-narrow js-hidden" id="example-other-address">
-
-              <h2 class="heading-medium">
+              <legend class="visuallyhidden">
                 Your other address
-              </h2>
+              </legend>
 
-              <fieldset>
+              <div class="form-group form-group-compound">
+                <label class="form-label" for="address-line-1">Street</label>
+                <input class="form-control" type="text" id="address-line-1">
+              </div>
 
-                <legend class="visuallyhidden">
-                  Your other address
-                </legend>
+              <div class="form-group">
+                <label class="form-label visuallyhidden" for="address-line-2">Street</label>
+                <input class="form-control" type="text" id="address-line-2">
+              </div>
 
-                <div class="form-group form-group-compound">
-                  <label class="form-label" for="address-line-1">Street</label>
-                  <input class="form-control" type="text" id="address-line-1">
-                </div>
+              <div class="form-group">
+                <label class="form-label" for="address-town">Town or City</label>
+                <input class="form-control form-control-1-4" type="text" id="address-town">
+              </div>
 
-                <div class="form-group">
-                  <label class="form-label visuallyhidden" for="address-line-2">Street</label>
-                  <input class="form-control" type="text" id="address-line-2">
-                </div>
+              <div class="form-group">
+                <label class="form-label" for="address-postcode">Postcode</label>
+                <input class="form-control form-control-1-8" type="text" id="address-postcode">
+              </div>
 
-                <div class="form-group">
-                  <label class="form-label" for="address-town">Town or City</label>
-                  <input class="form-control form-control-1-4" type="text" id="address-town">
-                </div>
+            </fieldset>
 
-                <div class="form-group">
-                  <label class="form-label" for="address-postcode">Postcode</label>
-                  <input class="form-control form-control-1-8" type="text" id="address-postcode">
-                </div>
+          </div>
+        </fieldset>
+      </div>
 
-              </fieldset>
+    </form>
 
-            </div>
-          </fieldset>
-        </div>
-
-      </form>
-
-    </div>
   </div>
-</main>
+</div>
+
 {% endblock %}

--- a/app/views/examples/elements/typography.html
+++ b/app/views/examples/elements/typography.html
@@ -5,63 +5,61 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
+
+<h1 class="heading-xlarge">
+  Typography
+</h1>
+
+<div class="text">
 
   <h1 class="heading-xlarge">
-    Typography
+    <span class="heading-secondary">A 27px section heading</span>
+    A 48px heading
   </h1>
 
-  <div class="text">
+  <p class="lede">
+    This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
+  </p>
 
-    <h1 class="heading-xlarge">
-      <span class="heading-secondary">A 27px section heading</span>
-      A 48px heading
-    </h1>
+  <h2 class="heading-large">A 36px heading</h2>
 
-    <p class="lede">
-      This is an intro paragraph at 24px. Maecenas faucibus mollis interdum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Curabitur blandit tempus porttitor. Vestibulum id ligula porta felis euismod semper.
-    </p>
+  <p>
+    This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
+  </p>
 
-    <h2 class="heading-large">A 36px heading</h2>
+  <h3 class="heading-medium">A 24px heading</h3>
 
-    <p>
-      This is a body copy paragraph at 19px. Donec id elit non mi porta gravida at eget metus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec sed odio dui. Aenean lacinia bibendum nulla sed consectetur. Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis.
-    </p>
+  <p>
+  Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
+  </p>
 
-    <h3 class="heading-medium">A 24px heading</h3>
+  <h4 class="heading-small">A 19px heading</h4>
 
-    <p>
-    Etiam porta sem malesuada magna mollis euismod. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.
-    </p>
+  <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
 
-    <h4 class="heading-small">A 19px heading</h4>
+  <ul class="list list-bullet">
+    <li>Here is a bulleted list.</li>
+    <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+    <li>Vestibulum id ligula porta felis euismod semper.</li>
+    <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
+  </ul>
 
-    <p>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Donec sed odio dui. Donec id elit non mi porta gravida at eget metus. Nullam id dolor id nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis ornare vel eu leo.</p>
+  <ol class="list list-number">
+    <li>Here is a numbered list.</li>
+    <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
+    <li>Vestibulum id ligula porta felis euismod semper.</li>
+    <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
+  </ol>
 
-    <ul class="list list-bullet">
-      <li>Here is a bulleted list.</li>
-      <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
-      <li>Vestibulum id ligula porta felis euismod semper.</li>
-      <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
-    </ul>
+  <ul class="list">
+    <li><a href="#">Related link</a></li>
+    <li><a href="#">Related link</a></li>
+    <li><a href="#">Related link</a></li>
+    <li><a href="#" class="bold-xsmall">More</a></li>
+  </ul>
 
-    <ol class="list list-number">
-      <li>Here is a numbered list.</li>
-      <li>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</li>
-      <li>Vestibulum id ligula porta felis euismod semper.</li>
-      <li>Integer posuere erat a ante venenatis dapibus posuere velit aliquet.</li>
-    </ol>
+</div>
 
-    <ul class="list">
-      <li><a href="#">Related link</a></li>
-      <li><a href="#">Related link</a></li>
-      <li><a href="#">Related link</a></li>
-      <li><a href="#" class="bold-xsmall">More</a></li>
-    </ul>
-
-  </div>
-
-</main>
 {% endblock %}

--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -6,110 +6,106 @@
 
 {% block content %}
 
-<main id="content" role="main">
+<div class="breadcrumbs">
+  <ol role="breadcrumbs">
+    <li><a href="/">GOV.UK prototype kit</a></li>
+  </ol>
+</div>
 
-  <div class="breadcrumbs">
-    <ol role="breadcrumbs">
-      <li><a href="/">GOV.UK prototype kit</a></li>
-    </ol>
+<h1 class="heading-xlarge">Example pages and patterns</h1>
+
+<p class="text">
+  Use these as the basis for your prototypes.
+  We recommend making copies of the examples rather than directly editing them.
+</p>
+
+<div class="grid-row">
+
+  <div class="column-third">
+    <h2 class="heading-medium">Page elements</h2>
+    <ul class="list list-bullet">
+      <li>
+        <a href="/examples/elements/grid-layout">
+          Grid layout
+        </a>
+      </li>
+      <li>
+        <a href="/examples/elements/typography">
+          Typography
+        </a>
+      </li>
+      <li>
+        <a href="/examples/elements/forms">
+          Basic form example
+        </a>
+      </li>
+      <li>
+        <a href="/examples/elements/radio-buttons-checkboxes">
+          Radio buttons and checkboxes
+        </a>
+      </li>
+      <li>
+        <a href="/examples/elements/toggled-content">
+          Toggling content
+        </a>
+      </li>
+    </ul>
   </div>
 
-  <h1 class="heading-xlarge">Example pages and patterns</h1>
+  <div class="column-third">
 
-  <p class="text">
-    Use these as the basis for your prototypes.
-    We recommend making copies of the examples rather than directly editing them.
-  </p>
-
-  <div class="grid-row">
-
-    <div class="column-third">
-      <h2 class="heading-medium">Page elements</h2>
-      <ul class="list list-bullet">
-        <li>
-          <a href="/examples/elements/grid-layout">
-            Grid layout
-          </a>
-        </li>
-        <li>
-          <a href="/examples/elements/typography">
-            Typography
-          </a>
-        </li>
-        <li>
-          <a href="/examples/elements/forms">
-            Basic form example
-          </a>
-        </li>
-        <li>
-          <a href="/examples/elements/radio-buttons-checkboxes">
-            Radio buttons and checkboxes
-          </a>
-        </li>
-        <li>
-          <a href="/examples/elements/toggled-content">
-            Toggling content
-          </a>
-        </li>
-      </ul>
-    </div>
-
-    <div class="column-third">
-
-      <h2 class="heading-medium">Page templates</h2>
-      <ul class="list list-bullet">
-        <li>
-          <a href="/examples/blank-govuk">
-            Blank
-          </a>
-        </li>
-        <li>
-          <a href="/examples/blank-unbranded">
-            Blank (non-GOV.UK)
-          </a>
-        </li>
-        <li>
-          <a href="/examples/start-page">
-            Start
-          </a>
-        </li>
-        <li>
-          <a href="/examples/question-page">
-            Question
-          </a>
-        </li>
-        <li>
-          <a href="/examples/check-your-answers-page">
-            Check your answers
-          </a>
-        </li>
-        <li>
-          <a href="/examples/confirmation-page">
-            Confirmation
-          </a>
-        </li>
-      </ul>
-    </div>
-
-    <div class="column-third">
-
-      <h2 class="heading-medium">Template features</h2>
-      <ul class="list list-bullet">
-        <li>
-          <a href="/examples/template-data">
-            Passing data into a template
-          </a>
-        </li>
-        <li>
-          <a href="/examples/template-partial-areas">
-            Template partial areas
-          </a>
-        </li>
-      </ul>
-    </div>
-
+    <h2 class="heading-medium">Page templates</h2>
+    <ul class="list list-bullet">
+      <li>
+        <a href="/examples/blank-govuk">
+          Blank
+        </a>
+      </li>
+      <li>
+        <a href="/examples/blank-unbranded">
+          Blank (non-GOV.UK)
+        </a>
+      </li>
+      <li>
+        <a href="/examples/start-page">
+          Start
+        </a>
+      </li>
+      <li>
+        <a href="/examples/question-page">
+          Question
+        </a>
+      </li>
+      <li>
+        <a href="/examples/check-your-answers-page">
+          Check your answers
+        </a>
+      </li>
+      <li>
+        <a href="/examples/confirmation-page">
+          Confirmation
+        </a>
+      </li>
+    </ul>
   </div>
 
-</main>
+  <div class="column-third">
+
+    <h2 class="heading-medium">Template features</h2>
+    <ul class="list list-bullet">
+      <li>
+        <a href="/examples/template-data">
+          Passing data into a template
+        </a>
+      </li>
+      <li>
+        <a href="/examples/template-partial-areas">
+          Template partial areas
+        </a>
+      </li>
+    </ul>
+  </div>
+
+</div>
 
 {% endblock %}

--- a/app/views/examples/question-page.html
+++ b/app/views/examples/question-page.html
@@ -6,50 +6,48 @@
 
 {% block content %}
 
-<main id="content" role="main">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-      <a class="link-back" href="/examples/">Back</a>
+    <a class="link-back" href="/examples/">Back</a>
 
-      <h1 class="heading-large">
-        What is your date of birth?
-      </h1>
+    <h1 class="heading-large">
+      What is your date of birth?
+    </h1>
 
-      <form class="form">
+    <form class="form">
 
-        <fieldset class="form-group">
-          <legend class="visuallyhidden">Date of birth</legend>
-          <div class="form-date">
+      <fieldset class="form-group">
+        <legend class="visuallyhidden">Date of birth</legend>
+        <div class="form-date">
 
-            <p class="form-hint">For example, 31 3 1980</p>
+          <p class="form-hint">For example, 31 3 1980</p>
 
-            <div class="form-group form-group-day">
-              <label for="dob-day">Day</label>
-              <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
-            </div>
-
-            <div class="form-group form-group-month">
-              <label for="dob-month">Month</label>
-              <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
-            </div>
-
-            <div class="form-group form-group-year">
-              <label for="dob-year">Year</label>
-              <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
-            </div>
-
+          <div class="form-group form-group-day">
+            <label for="dob-day">Day</label>
+            <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
           </div>
-        </fieldset>
 
-        <div class="form-group">
-          <input class="button" type="submit" value="Continue">
+          <div class="form-group form-group-month">
+            <label for="dob-month">Month</label>
+            <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+          </div>
+
+          <div class="form-group form-group-year">
+            <label for="dob-year">Year</label>
+            <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2014">
+          </div>
+
         </div>
+      </fieldset>
 
-      </form>
+      <div class="form-group">
+        <input class="button" type="submit" value="Continue">
+      </div>
 
-    </div>
+    </form>
+
   </div>
-</main>
+</div>
 
 {% endblock %}

--- a/app/views/examples/start-page.html
+++ b/app/views/examples/start-page.html
@@ -14,61 +14,57 @@
 
 {% block content %}
 
-<main id="content" role="main">
+<div class="breadcrumbs">
+  <ol role="breadcrumbs">
+    <li><a href="http://www.gov.uk">Home</a></li>
+    <li><a href="">Section</a></li>
+    <li>Subsection</li>
+  </ol>
+</div>
 
-  <div class="breadcrumbs">
-    <ol role="breadcrumbs">
-      <li><a href="http://www.gov.uk">Home</a></li>
-      <li><a href="">Section</a></li>
-      <li>Subsection</li>
-    </ol>
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <h1 class="heading-xlarge">
+      {% if serviceName %} {{ serviceName }} {% endif %}
+    </h1>
+
+    <p>Use this service to:</p>
+
+    <ul class="list list-bullet">
+      <li>do something</li>
+      <li>update your name, address or other details</li>
+      <li>you need to do this in order to do something else</li>
+    </uL>
+
+    <p>Registering takes around 5 minutes.</p>
+
+    <p>
+      <a class="button button-start" href="#" role="button">Start now</a>
+    </p>
+
+    <h2 class="heading-medium">Before you start</h2>
+
+    <p>You can also <a href="#">register by post.</a></p>
+
+    <p>The online service is also available in <a href="#">Welsh (Cymraeg).</a></p>
+
+    <p>You can’t register for this service if you’re in the UK illegally.</p>
+
   </div>
+  <div class="column-third">
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="related-links">
+      <h2 class="heading-medium">Subsection</h2>
 
-      <h1 class="heading-xlarge">
-        {% if serviceName %} {{ serviceName }} {% endif %}
-      </h1>
-
-      <p>Use this service to:</p>
-
-      <ul class="list list-bullet">
-        <li>do something</li>
-        <li>update your name, address or other details</li>
-        <li>you need to do this in order to do something else</li>
-      </uL>
-
-      <p>Registering takes around 5 minutes.</p>
-
-      <p>
-        <a class="button button-start" href="#" role="button">Start now</a>
-      </p>
-
-      <h2 class="heading-medium">Before you start</h2>
-
-      <p>You can also <a href="#">register by post.</a></p>
-
-      <p>The online service is also available in <a href="#">Welsh (Cymraeg).</a></p>
-
-      <p>You can’t register for this service if you’re in the UK illegally.</p>
-
+      <ul class="font-xsmall">
+        <li><a href="#">Related link</a></li>
+        <li><a href="#">Related link</a></li>
+        <li><a href="#" class="bold-xsmall">More</a></li>
+      </ul>
     </div>
-    <div class="column-third">
 
-      <div class="related-links">
-        <h2 class="heading-medium">Subsection</h2>
-
-        <ul class="font-xsmall">
-          <li><a href="#">Related link</a></li>
-          <li><a href="#">Related link</a></li>
-          <li><a href="#" class="bold-xsmall">More</a></li>
-        </ul>
-      </div>
-
-    </div>
   </div>
-
-</main>
+</div>
 
 {% endblock %}

--- a/app/views/examples/template-data.html
+++ b/app/views/examples/template-data.html
@@ -5,27 +5,25 @@
 {% endblock %}
 
 {% block content %}
-<main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
+{% include "includes/breadcrumb_examples.html" %}
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-      <h1 class="heading-xlarge">
-        Passing data into pages
-      </h1>
+    <h1 class="heading-xlarge">
+      Passing data into pages
+    </h1>
 
-      <p>
-        The example route defined in <code class="code">/routes.js</code> is passing the string '{{ name }}' to this page, via the variable called 'name'.
-      </p>
+    <p>
+      The example route defined in <code class="code">/routes.js</code> is passing the string '{{ name }}' to this page, via the variable called 'name'.
+    </p>
 
-      <p>
-        Have a look at the source for this page in your text editor to see how it works: <code class="code">/app/views/examples/template-data.html</code>
-      </p>
+    <p>
+      Have a look at the source for this page in your text editor to see how it works: <code class="code">/app/views/examples/template-data.html</code>
+    </p>
 
-    </div>
   </div>
+</div>
 
-</main>
 {% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -6,58 +6,54 @@
 
 {% block content %}
 
-<main id="content" role="main">
-  <div class="grid-row">
-    <div class="column-two-thirds">
+<div class="grid-row">
+  <div class="column-two-thirds">
 
-      <h1 class="heading-xlarge">The GOV.UK prototype kit</h1>
+    <h1 class="heading-xlarge">The GOV.UK prototype kit</h1>
 
-      <p>
-        This kit lets you rapidly create HTML prototypes of GOV.UK services.
-      </p>
+    <p>
+      This kit lets you rapidly create HTML prototypes of GOV.UK services.
+    </p>
 
-      <p>
-        It contains all you need to prototype anything from simple static pages to complex, data-driven transactions.
-      </p>
+    <p>
+      It contains all you need to prototype anything from simple static pages to complex, data-driven transactions.
+    </p>
 
-      <h2 class="heading-medium">About this page</h2>
+    <h2 class="heading-medium">About this page</h2>
 
-      <p>We recommend you add links to your prototype to this page, rather than delete it.
-        You'll find this page in the kit at '/app/views/index.html'.</p>
-      <p>You can change the service name by editing the file '/app/config.js'.</p>
+    <p>We recommend you add links to your prototype to this page, rather than delete it.
+      You'll find this page in the kit at '/app/views/index.html'.</p>
+    <p>You can change the service name by editing the file '/app/config.js'.</p>
 
-			<h2 class="heading-medium">Examples and documentation</h2>
+		<h2 class="heading-medium">Examples and documentation</h2>
 
-			<ul class="list list-bullet">
-				<li><a href="/examples">Example pages and patterns</a></li>
-				<li><a href="https://github.com/alphagov/govuk_prototype_kit/tree/master/docs">
-						Read the full documentation</a></li>
-			</ul>
+		<ul class="list list-bullet">
+			<li><a href="/examples">Example pages and patterns</a></li>
+			<li><a href="https://github.com/alphagov/govuk_prototype_kit/tree/master/docs">
+					Read the full documentation</a></li>
+		</ul>
 
-      <h2 class="heading-medium">Other resources</h2>
+    <h2 class="heading-medium">Other resources</h2>
 
-			<ul class="list list-bullet">
-				<li>
-					<a href="http://govuk-elements.herokuapp.com/snippets/">
-						Guide to GOV.UK Elements
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/service-manual">
-						Service design manual
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/design-principles">
-						Government Digital Service Design Principles
-					</a>
-				</li>
-			</ul>
+		<ul class="list list-bullet">
+			<li>
+				<a href="http://govuk-elements.herokuapp.com/snippets/">
+					Guide to GOV.UK Elements
+				</a>
+			</li>
+			<li>
+				<a href="https://www.gov.uk/service-manual">
+					Service design manual
+				</a>
+			</li>
+			<li>
+				<a href="https://www.gov.uk/design-principles">
+					Government Digital Service Design Principles
+				</a>
+			</li>
+		</ul>
 
-    </div>
   </div>
-</main>
+</div>
 
 {% endblock %}
-
-

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -12,6 +12,10 @@
   with-proposition
 {% endblock %}
 
+{% block phase_banner %}
+
+{% endblock %}
+
 {% block body_end %}
   {% include "includes/scripts.html" %}
 {% endblock %}

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -31,14 +31,8 @@ An example of this can be seen in the [question-page.html](../app/views/examples
 
 ## Add a phase banner
 
-Include either the alpha or beta phase banner from the `app/views/includes/` folder.
+In the `phase_banner` block in `layout.html` add either;
 
-### How to include an Alpha banner
+`{% include "includes/phase_banner_alpha.html" %}` to add an Alpha phase banner, or add;
 
-    {% include "includes/phase_banner_alpha.html" %}
-
-### How to include a Beta banner
-
-    {% include "includes/phase_banner_beta.html" %}
-
-
+`{% include "includes/phase_banner_beta.html" %}` to add a Beta phase banner.

--- a/lib/govuk_template.html
+++ b/lib/govuk_template.html
@@ -68,13 +68,13 @@
     </div>
 
     <div id="global-cookie-message">
-      
+
         {% block cookie_message %}{% endblock %}
-      
+
     </div>
     <!--end global-cookie-message-->
 
-    
+
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
@@ -89,14 +89,18 @@
       </div>
     </header>
     <!--end header-->
-    
+
 
     {% block after_header %}{% endblock %}
 
     <div id="global-header-bar"></div>
     <!--end global-header-bar-->
 
+    <main id="content" role="main">
+    {% block phase_banner %}{% endblock %}
     {% block content %}{% endblock %}
+    </main>
+    <!--end main-->
 
     <footer class="group js-footer" id="footer" role="contentinfo">
 
@@ -109,9 +113,9 @@
 
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-              
+
                 {% block licence_message %}<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>{% endblock %}
-              
+
             </div>
           </div>
 


### PR DESCRIPTION
Makes it easier to add a phase banner to every page on a prototype service using a single layout style.

Also:
Push main tag up to govuk_template. 
Remove main tag from examples. 
Update docs. 