### PR TITLE
Adding browser-sync to the kit.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ exports.basicAuth = function(username, password) {
 			console.log('Username or password is not set.');
 			return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/deploying.md#3-set-a-username-and-password">See guidance for setting these</a>.</p>');
 		}
-		
+
 		var user = basicAuth(req);
 
 		if (!user || user.name !== username || user.pass !== password) {
@@ -33,7 +33,7 @@ exports.basicAuth = function(username, password) {
 	};
 };
 
-exports.findAvailablePort = function(app){
+exports.findAvailablePort = function(app,callback){
 
   var port = (process.env.PORT || 3000);
 
@@ -42,8 +42,7 @@ exports.findAvailablePort = function(app){
   portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
 
     if (port == availablePort){
-      app.listen(port);
-      console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+      callback(port);
     }
     else {
       // Default port in use - offer to change to available port
@@ -66,8 +65,8 @@ exports.findAvailablePort = function(app){
         if (result.answer.match(/y(es)?/i) ) {
           // User answers yes
           port = availablePort;
-          app.listen(port);
           console.log('Changed to port ' + port + '   url: http://localhost:' + port);
+          callback(port);
         }
         else {
           // User answers no - exit

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
+    "browser-sync": "^2.11.1",
     "consolidate": "0.x",
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 var path = require('path'),
     express = require('express'),
+    browserSync = require('browser-sync'),
     nunjucks = require('express-nunjucks'),
     routes = require(__dirname + '/app/routes.js'),
     favicon = require('serve-favicon'),
@@ -94,5 +95,21 @@ app.get(/^\/([^.]+)$/, function (req, res) {
 });
 
 // start the app
-
-utils.findAvailablePort(app);
+utils.findAvailablePort(app, function(port) {
+  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+  if (env === 'production') {
+    app.listen(port);
+  } else {
+    app.listen(port,function()
+    {
+      browserSync({
+        proxy:'localhost:'+port,
+        port:port+1,
+        ui:false,
+        files:['public/**/*.{js,css,png}','app/views/**/*.html'],
+        ghostmode:{clicks:true, forms: true, scroll:true},
+        open:false,
+      });
+    });
+  }
+});


### PR DESCRIPTION
This addresses issue #84.

I've changed the `findAvailablePort` function in `utils.js` to include a callback which passes back the port number. 

Then in `server.js` I start the the app either with or without browser-sync depending on whether we're in `production` or not.