### PR TITLE
Add default cookie message

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -11,6 +11,10 @@ module.exports = {
   port: '3000',
 
   // Enable or disable password protection on production
-  useAuth: 'true'
+  useAuth: 'true',
+
+  // Cookie warning - update link to service's cookie page.
+  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#" title="Find out more about cookies">Find out more about cookies</a>'
 
 };
+	

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -4,6 +4,10 @@
   {% include "includes/head.html" %}
 {% endblock %}
 
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
 {% block proposition_header %}
   {% include "includes/propositional_navigation.html" %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -59,6 +59,7 @@ app.use(function (req, res, next) {
 // Add variables that are available in all views
 app.use(function (req, res, next) {
   res.locals.serviceName=config.serviceName;
+  res.locals.cookieText=config.cookieText;
   next();
 });
 


### PR DESCRIPTION
This PR adds a default cookie message to `config.js`. We added this a while back but it seems to have disappeared.

Before:
![screen shot 2016-02-15 at 16 22 41](https://cloud.githubusercontent.com/assets/2204224/13054211/69ce9e5e-d400-11e5-807e-19db9597f206.png)

After:
![screen shot 2016-02-15 at 16 22 28](https://cloud.githubusercontent.com/assets/2204224/13054214/6ea8e84e-d400-11e5-9c57-f428b6493d3e.png)
