### PR TITLE
Update the GOV.UK template and remove napa as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.1
+  - 4.0
 before_install:
   - npm install -g grunt-cli
 install:

--- a/lib/govuk_template.html
+++ b/lib/govuk_template.html
@@ -11,19 +11,19 @@
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script>
 
-    <!--[if gt IE 8]><!--><link href="{{ asset_path }}stylesheets/govuk-template.css?0.16.0" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-    <!--[if IE 6]><link href="{{ asset_path }}stylesheets/govuk-template-ie6.css?0.16.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 7]><link href="{{ asset_path }}stylesheets/govuk-template-ie7.css?0.16.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 8]><link href="{{ asset_path }}stylesheets/govuk-template-ie8.css?0.16.0" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if gt IE 8]><!--><link href="{{ asset_path }}stylesheets/govuk-template.css?0.16.4" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ asset_path }}stylesheets/govuk-template-ie6.css?0.16.4" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 7]><link href="{{ asset_path }}stylesheets/govuk-template-ie7.css?0.16.4" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path }}stylesheets/govuk-template-ie8.css?0.16.4" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
 
-    <link href="{{ asset_path }}stylesheets/govuk-template-print.css?0.16.0" media="print" rel="stylesheet" type="text/css" />
+    <link href="{{ asset_path }}stylesheets/govuk-template-print.css?0.16.4" media="print" rel="stylesheet" type="text/css" />
 
     <!--[if IE 8]>
     <script type="text/javascript">
       (function(){if(window.opera){return;}
        setTimeout(function(){var a=document,g,b={families:(g=
-       ["nta"]),urls:["{{ asset_path }}stylesheets/fonts-ie8.css?0.16.0"]},
-       c="{{ asset_path }}javascripts/vendor/goog/webfont-debug.js?0.16.0",d="script",
+       ["nta"]),urls:["{{ asset_path }}stylesheets/fonts-ie8.css?0.16.4"]},
+       c="{{ asset_path }}javascripts/vendor/goog/webfont-debug.js?0.16.4",d="script",
        e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
        ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
        .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
@@ -31,27 +31,27 @@
     </script>
     <![endif]-->
     <!--[if gte IE 9]><!-->
-      <link href="{{ asset_path }}stylesheets/fonts.css?0.16.0" media="all" rel="stylesheet" type="text/css" />
+      <link href="{{ asset_path }}stylesheets/fonts.css?0.16.4" media="all" rel="stylesheet" type="text/css" />
     <!--<![endif]-->
 
 
     <!--[if lt IE 9]>
-      <script src="{{ asset_path }}javascripts/ie.js?0.16.0" type="text/javascript"></script>
+      <script src="{{ asset_path }}javascripts/ie.js?0.16.4" type="text/javascript"></script>
     <![endif]-->
 
-    <link rel="shortcut icon" href="{{ asset_path }}images/favicon.ico?0.16.0" type="image/x-icon" />
+    <link rel="shortcut icon" href="{{ asset_path }}images/favicon.ico?0.16.4" type="image/x-icon" />
 
     <!-- Size for iPad and iPad mini (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.16.0">
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.16.4">
     <!-- Size for iPhone and iPod touch (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path }}images/apple-touch-icon-120x120.png?0.16.0">
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path }}images/apple-touch-icon-120x120.png?0.16.4">
     <!-- Size for iPad 2 and iPad mini (standard resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path }}images/apple-touch-icon-76x76.png?0.16.0">
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path }}images/apple-touch-icon-76x76.png?0.16.4">
     <!-- Default non-defined size, also used for Android 2.1+ devices -->
-    <link rel="apple-touch-icon-precomposed" href="{{ asset_path }}images/apple-touch-icon-60x60.png?0.16.0">
+    <link rel="apple-touch-icon-precomposed" href="{{ asset_path }}images/apple-touch-icon-60x60.png?0.16.4">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="{{ asset_path }}images/opengraph-image.png?0.16.0">
+    <meta property="og:image" content="{{ asset_path }}images/opengraph-image.png?0.16.4">
 
     {% block head %}{% endblock %}
   </head>
@@ -80,7 +80,7 @@
         <div class="header-global">
           <div class="header-logo">
             <a href="{{ homepage_url|default('https://www.gov.uk') }}" title="{{ logo_link_title|default('Go to the GOV.UK homepage') }}" id="logo" class="content">
-              <img src="{{ asset_path }}images/gov.uk_logotype_crown_invert_trans.png?0.16.0" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
+              <img src="{{ asset_path }}images/gov.uk_logotype_crown_invert_trans.png?0.16.4" width="35" height="31" alt=""> {{ global_header_text|default('GOV.UK') }}
             </a>
           </div>
           {% block inside_header %}{% endblock %}
@@ -126,7 +126,7 @@
 
     <div id="global-app-error" class="app-error hidden"></div>
 
-    <script src="{{ asset_path }}javascripts/govuk-template.js?0.16.0" type="text/javascript"></script>
+    <script src="{{ asset_path }}javascripts/govuk-template.js?0.16.4" type="text/javascript"></script>
 
     {% block body_end %}{% endblock %}
   </body>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "node": ">=4.0 <5.0"
   },
   "scripts": {
-    "start": "node start.js",
-    "install": "napa"
+    "start": "node start.js"
   },
   "dependencies": {
     "basic-auth": "^1.0.3",
@@ -21,6 +20,7 @@
     "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
     "govuk_frontend_toolkit": "^4.6.0",
     "govuk_template_mustache": "^0.16.0",
+    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.16.4/jinja_govuk_template-0.16.4.tgz",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",
@@ -30,13 +30,9 @@
     "grunt-sync": "^0.5.1",
     "hogan.js": "3.0.2",
     "minimist": "0.0.8",
-    "napa": "^2.2.0",
     "portscanner": "^1.0.0",
     "prompt": "^0.2.14",
     "readdir": "0.0.6",
     "serve-favicon": "2.3.0"
-  },
-  "napa": {
-    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.16.0/jinja_govuk_template-0.16.0.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
     "govuk_frontend_toolkit": "^4.6.0",
-    "govuk_template_mustache": "^0.16.0",
+    "govuk_template_mustache": "^0.16.4",
     "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.16.4/jinja_govuk_template-0.16.4.tgz",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
- Update the govuk template to 0.16.4
- Remove napa as a dependecy

From the [GOV.UK template](https://github.com/alphagov/govuk_template) changelog.md

```
# 0.16.4

- Fix publish the Jinja version of the template with a `package.json`
for those
  consuming it with NPM


# 0.16.3

- make the Django version of the template into a proper Python package
- publish the Jinja version of the template with a `package.json` for
those
  consuming it with NPM

# 0.16.2

- more static assets added to `assets.precompile` to improve
  compatibility with apps running rails > 4.2.5

# 0.16.1

- Fix colour of logo when in `:active` state
```
