### PR TITLE
fix port restart issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .sass-cache
 .DS_Store
 .start.pid
+port.tmp
 public
 govuk_modules
 node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .sass-cache
 .DS_Store
 .start.pid
-port.tmp
+.port.tmp
 public
 govuk_modules
 node_modules/*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 var basicAuth = require('basic-auth'),
     prompt = require('prompt'),
-    portScanner = require('portscanner');
+    portScanner = require('portscanner'),
+    fs = require('fs');
 
 /**
  * Simple basic auth middleware for use with Express 4.x.
@@ -35,17 +36,26 @@ exports.basicAuth = function(username, password) {
 
 exports.findAvailablePort = function(app){
 
-  var port = (process.env.PORT || 3000);
+  var port = null;
+
+  try {
+    port = Number(fs.readFileSync(__dirname+'/../port.tmp'));
+  } catch (e){
+    port = (process.env.PORT || 3000);
+  }
 
   console.log('');
+
   // Check that default port is free, else offer to change
   portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
 
     if (port == availablePort){
+
       app.listen(port);
       console.log('Listening on port ' + port + '   url: http://localhost:' + port);
-    }
-    else {
+
+    } else {
+
       // Default port in use - offer to change to available port
       console.error("ERROR: Port " + port + " in use - you may have another prototype running.\n");
       // Set up prompt settings
@@ -63,17 +73,22 @@ exports.findAvailablePort = function(app){
         pattern: /y(es)?|no?/i,
         message: 'Please enter y or n'
       }], function (err, result) {
+
         if (result.answer.match(/y(es)?/i) ) {
+
           // User answers yes
           port = availablePort;
+          fs.writeFileSync(__dirname+'/../port.tmp', port);
           app.listen(port);
           console.log('Changed to port ' + port + '   url: http://localhost:' + port);
-        }
-        else {
+
+        } else {
+
           // User answers no - exit
           console.log('\nYou can set a new default port in server.js, or by running the server with PORT=XXXX');
           console.log("\nExit by pressing 'ctrl + c'");
           process.exit(0);
+
         }
       });
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,8 @@
 var basicAuth = require('basic-auth'),
-    prompt = require('prompt'),
-    portScanner = require('portscanner'),
+    config = require(__dirname + '/../app/config.js'),
     fs = require('fs');
+    portScanner = require('portscanner'),
+    prompt = require('prompt');
 
 /**
  * Simple basic auth middleware for use with Express 4.x.
@@ -41,7 +42,7 @@ exports.findAvailablePort = function(app){
   try {
     port = Number(fs.readFileSync(__dirname+'/../port.tmp'));
   } catch (e){
-    port = (process.env.PORT || 3000);
+    port = (process.env.PORT || config.port);
   }
 
   console.log('');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ exports.findAvailablePort = function(app){
   try {
     port = Number(fs.readFileSync(__dirname+'/../.port.tmp'));
   } catch (e){
-    port = (process.env.PORT || config.port.tmp);
+    port = (process.env.PORT || config.port);
   }
 
   console.log('');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,9 +40,9 @@ exports.findAvailablePort = function(app){
   var port = null;
 
   try {
-    port = Number(fs.readFileSync(__dirname+'/../port.tmp'));
+    port = Number(fs.readFileSync(__dirname+'/../.port.tmp'));
   } catch (e){
-    port = (process.env.PORT || config.port);
+    port = (process.env.PORT || config.port.tmp);
   }
 
   console.log('');
@@ -76,10 +76,9 @@ exports.findAvailablePort = function(app){
       }], function (err, result) {
 
         if (result.answer.match(/y(es)?/i) ) {
-
           // User answers yes
           port = availablePort;
-          fs.writeFileSync(__dirname+'/../port.tmp', port);
+          fs.writeFileSync(__dirname+'/../.port.tmp', port);
           app.listen(port);
           console.log('Changed to port ' + port + '   url: http://localhost:' + port);
 

--- a/start.js
+++ b/start.js
@@ -6,9 +6,9 @@ if (!fs.existsSync(__dirname + '/node_modules')) {
   process.exit(0);
 }
 
-// remove port.tmp if it exists  
+// remove .port.tmp if it exists  
 try {
-  fs.unlinkSync(__dirname + '/port.tmp');
+  fs.unlinkSync(__dirname + '/.port.tmp');
 } catch(e){}
 
 var gruntfile = __dirname + '/Gruntfile.js';
@@ -19,9 +19,9 @@ require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
 
 process.on('SIGINT', function() {
 
-  // remove port.tmp if it exists  
+  // remove .port.tmp if it exists  
   try {
-    fs.unlinkSync(__dirname + '/port.tmp');
+    fs.unlinkSync(__dirname + '/.port.tmp');
   } catch(e){}
 
   process.exit(0);

--- a/start.js
+++ b/start.js
@@ -1,16 +1,25 @@
 // Check for `node_modules` folder and warn if missing
 var fs = require('fs');
+
 if (!fs.existsSync(__dirname + '/node_modules')) {
   console.error('ERROR: Node module folder missing. Try running `npm install`');
   process.exit(0);
 }
 
 var gruntfile = __dirname + '/Gruntfile.js';
+
 require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({
   'gruntfile' : gruntfile
 });
 
 process.on('SIGINT', function() {
-  process.kill(process.pid, 'SIGTERM');
-  process.exit();
+
+  // remove port.tmp if it exists  
+  try {
+    fs.unlinkSync(__dirname + '/port.tmp');
+  } catch(e){}
+
+  // process.kill(process.pid, 'SIGTERM');
+  process.exit(0);
+
 });

--- a/start.js
+++ b/start.js
@@ -24,7 +24,6 @@ process.on('SIGINT', function() {
     fs.unlinkSync(__dirname + '/port.tmp');
   } catch(e){}
 
-  // process.kill(process.pid, 'SIGTERM');
   process.exit(0);
 
 });

--- a/start.js
+++ b/start.js
@@ -6,6 +6,11 @@ if (!fs.existsSync(__dirname + '/node_modules')) {
   process.exit(0);
 }
 
+// remove port.tmp if it exists  
+try {
+  fs.unlinkSync(__dirname + '/port.tmp');
+} catch(e){}
+
 var gruntfile = __dirname + '/Gruntfile.js';
 
 require(__dirname + '/node_modules/grunt/lib/grunt.js').cli({


### PR DESCRIPTION
fix port restart issue #148

when a new port is automatically chosen, it's stored in a file: `/port.tmp`

when the kit restarts on a file change, it looks for the port here first

when the kit is closed (`ctrl+c`) the `port.tmp` file is deleted.