### PR TITLE
always convert port to Number

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ exports.findAvailablePort = function(app){
   try {
     port = Number(fs.readFileSync(__dirname+'/../.port.tmp'));
   } catch (e){
-    port = (process.env.PORT || config.port);
+    port = Number(process.env.PORT || config.port);
   }
 
   console.log('');


### PR DESCRIPTION
previously it could be a string, and when PortScanner does `port + 50` it would do a string addition (300050)