### PR TITLE
Redirect .html and .htm if in url path

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ if (typeof(routes) != "function"){
 }
 
 // Strip .html and .htm if provided
-app.get(/.html?$/i, function (req, res){
+app.get(/\.html?$/i, function (req, res){
   var path = req.path;
   var parts = path.split('.');
   parts.pop();

--- a/server.js
+++ b/server.js
@@ -75,6 +75,15 @@ if (typeof(routes) != "function"){
   app.use("/", routes);
 }
 
+// Strip .html and .htm if provided
+app.get(/.html?$/i, function (req, res){
+  var path = req.path;
+  var parts = path.split('.');
+  parts.pop();
+  path = parts.join('.');
+  res.redirect(path);
+});
+
 // auto render any view that exists
 app.get(/^\/([^.]+)$/, function (req, res) {
 


### PR DESCRIPTION
This PR redirects urls that end in `.html` or `.htm` to the same url with the extension removed.

This should improve the situation where a user sees a path / filename somewhere else and attempts to visit that in the browser.

Fixes #102 