### PR TITLE
Stop prototypes being indexed by search engines.

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,6 +67,12 @@ app.use(function (req, res, next) {
 });
 
 // Disallow search index idexing
+app.use(function (req, res, next) {
+  // Setting headers stops pages being indexed even if indexed pages link to them.
+  res.setHeader('X-Robots-Tag', 'noindex');
+  next();
+});
+
 app.get('/robots.txt', function (req, res) {
   res.type('text/plain');
   res.send("User-agent: *\nDisallow: /");

--- a/server.js
+++ b/server.js
@@ -66,6 +66,12 @@ app.use(function (req, res, next) {
   next();
 });
 
+// Disallow search index idexing
+app.get('/robots.txt', function (req, res) {
+  res.type('text/plain');
+  res.send("User-agent: *\nDisallow: /");
+});
+
 // routes (found in app/routes.js)
 if (typeof(routes) != "function"){
   console.log(routes.bind);


### PR DESCRIPTION
Prototypes should never be indexed by search engines. 

This serves PR does two things:
* Serves a `robots.txt` file that disallows search index indexing.
* Sets `X-Robots-Tag` to `noindex`. This should stop pages getting indexed if they're being linked to by an indexed page.

Fixes #166 

Note: I've tested the robots file, but unsure how to test the `X-Robots-Tag`. It appears in the headers, but haven't found a tool that will verify it's actually doing what it should.