### PR TITLE
Fix closing </span> element

### DIFF
--- a/app/views/examples/start-page.html
+++ b/app/views/examples/start-page.html
@@ -62,7 +62,7 @@
           <ul class="font-xsmall">
             <li><a href="#">Related link</a></li>
             <li><a href="#">Related link</a></li>
-            <li><a href="#" class="bold-xsmall">More <span class="visuallyhidden">in Subsection</span</a></li>
+            <li><a href="#" class="bold-xsmall">More <span class="visuallyhidden">in Subsection</span></a></li>
           </ul>
         </nav>
       </aside>


### PR DESCRIPTION
This is causing the repetition of the .bold-xsmall link, which is breaking the OGL logo in the footer.

Adding the missing `>` fixes #167.