### PR TITLE
Force SSL on production

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -13,6 +13,9 @@ module.exports = {
   // Enable or disable password protection on production
   useAuth: 'true',
 
+  // Enable or disable HTTPs / SSL on production
+  useSSL: 'true',
+
   // Cookie warning - update link to service's cookie page.
   cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#" title="Find out more about cookies">Find out more about cookies</a>'
 

--- a/app/config.js
+++ b/app/config.js
@@ -13,8 +13,8 @@ module.exports = {
   // Enable or disable password protection on production
   useAuth: 'true',
 
-  // Enable or disable HTTPs / SSL on production
-  useSSL: 'true',
+  // Force HTTP to redirect to HTTPs on production
+  useHttps: 'true',
 
   // Cookie warning - update link to service's cookie page.
   cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#" title="Find out more about cookies">Find out more about cookies</a>'

--- a/app/views/examples/start-page.html
+++ b/app/views/examples/start-page.html
@@ -18,7 +18,7 @@
 
   <div class="breadcrumbs">
     <ol>
-      <li><a href="http://www.gov.uk">Home</a></li>
+      <li><a href="https://www.gov.uk">Home</a></li>
       <li><a href="">Section</a></li>
       <li>Subsection</li>
     </ol>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -38,7 +38,7 @@
 
 			<ul class="list list-bullet">
 				<li>
-					<a href="http://govuk-elements.herokuapp.com/snippets/">
+					<a href="https://govuk-elements.herokuapp.com/snippets/">
 						Guide to GOV.UK Elements
 					</a>
 				</li>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -95,3 +95,10 @@ exports.findAvailablePort = function(app){
   });
 
 }
+
+exports.forceSSL = function(req, res, next) {
+  if (req.headers['x-forwarded-proto'] !== 'https') {
+    return res.redirect(301, ['https://', req.get('Host'), req.url].join(''));
+  }
+  next();
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,7 +98,8 @@ exports.findAvailablePort = function(app){
 
 exports.forceSSL = function(req, res, next) {
   if (req.headers['x-forwarded-proto'] !== 'https') {
-    return res.redirect(301, ['https://', req.get('Host'), req.url].join(''));
+    console.log('Redirecting request to HTTPs');
+    return res.redirect(302, ['https://', req.get('Host'), req.url].join(''));
   }
   next();
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,9 +96,9 @@ exports.findAvailablePort = function(app){
 
 }
 
-exports.forceSSL = function(req, res, next) {
+exports.forceHttps = function(req, res, next) {
   if (req.headers['x-forwarded-proto'] !== 'https') {
-    console.log('Redirecting request to HTTPs');
+    console.log('Redirecting request to https');
     return res.redirect(302, ['https://', req.get('Host'), req.url].join(''));
   }
   next();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,7 +99,8 @@ exports.findAvailablePort = function(app){
 exports.forceHttps = function(req, res, next) {
   if (req.headers['x-forwarded-proto'] !== 'https') {
     console.log('Redirecting request to https');
-    return res.redirect(302, ['https://', req.get('Host'), req.url].join(''));
+    // 302 temporary - this is a feature that can be disabled
+    return res.redirect(302, 'https://' + req.get('Host') + req.url);
   }
   next();
 };

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ var path = require('path'),
     packageJson = require(__dirname + '/package.json'),
 
 // Grab environment variables specified in Procfile or as Heroku config vars
-    releaseVersion = packageJson.version;
+    releaseVersion = packageJson.version,
     username = process.env.USERNAME,
     password = process.env.PASSWORD,
     env      = process.env.NODE_ENV || 'development',
@@ -69,7 +69,7 @@ app.use(function (req, res, next) {
 });
 
 // Force HTTPs on production connections
-if (env === 'production' && useSSL === 'true') {
+if (env === 'production' && useSSL === 'true'){
   app.use(utils.forceSSL);
 }
 

--- a/server.js
+++ b/server.js
@@ -17,11 +17,11 @@ var path = require('path'),
     password = process.env.PASSWORD,
     env      = process.env.NODE_ENV || 'development',
     useAuth  = process.env.USE_AUTH || config.useAuth,
-    useSSL  = process.env.USE_SSL || config.useSSL;
+    useHttps  = process.env.USE_HTTPS || config.useHttps;
 
     env      = env.toLowerCase();
     useAuth  = useAuth.toLowerCase();
-    useSSL   = useSSL.toLowerCase();
+    useHttps   = useHttps.toLowerCase();
 
 // Authenticate against the environment-provided credentials, if running
 // the app in production (Heroku, effectively)
@@ -69,8 +69,8 @@ app.use(function (req, res, next) {
 });
 
 // Force HTTPs on production connections
-if (env === 'production' && useSSL === 'true'){
-  app.use(utils.forceSSL);
+if (env === 'production' && useHttps === 'true'){
+  app.use(utils.forceHttps);
 }
 
 // Disallow search index idexing

--- a/server.js
+++ b/server.js
@@ -66,6 +66,11 @@ app.use(function (req, res, next) {
   next();
 });
 
+// Force HTTPs on production connections
+if (env === 'production') {
+  app.use(utils.forceSSL);
+}
+
 // Disallow search index idexing
 app.use(function (req, res, next) {
   // Setting headers stops pages being indexed even if indexed pages link to them.

--- a/server.js
+++ b/server.js
@@ -16,10 +16,12 @@ var path = require('path'),
     username = process.env.USERNAME,
     password = process.env.PASSWORD,
     env      = process.env.NODE_ENV || 'development',
-    useAuth  = process.env.USE_AUTH || config.useAuth;
+    useAuth  = process.env.USE_AUTH || config.useAuth,
+    useSSL  = process.env.USE_SSL || config.useSSL;
 
     env      = env.toLowerCase();
     useAuth  = useAuth.toLowerCase();
+    useSSL   = useSSL.toLowerCase();
 
 // Authenticate against the environment-provided credentials, if running
 // the app in production (Heroku, effectively)
@@ -67,7 +69,7 @@ app.use(function (req, res, next) {
 });
 
 // Force HTTPs on production connections
-if (env === 'production') {
+if (env === 'production' && useSSL === 'true') {
   app.use(utils.forceSSL);
 }
 


### PR DESCRIPTION
This redirects requests to https. 

Heroku has SSL built in, so for most prototypes, things should work as normal, except with SSL.

Note: I think this is a breaking change, since it requires production servers to have HTTPs set up.