### PR TITLE
Remove target="_blank"

### DIFF
--- a/docs/install/run-the-kit.md
+++ b/docs/install/run-the-kit.md
@@ -20,7 +20,7 @@ Listening on port 3000 url: http://localhost:3000
 
 ## Check it works
 
-In your web browser, visit <a href="http://localhost:3000" target="_blank">http://localhost:3000 (opens in a new tab)</a>
+In your web browser, visit <a href="http://localhost:3000">http://localhost:3000</a>
 
 You should see the prototype welcome page.
 


### PR DESCRIPTION
Github must strip out the target, so the link doesn't open in a new tab