### PR TITLE
Security guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ The prototype kit provides a simple way to make interactive prototypes that look
 
 Read the [project principles](docs/principles.md).
 
-> You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately. 
+## Security
+
+If you publish your prototypes online, they **must** be protected by a [username and password](docs/guides/publishing-on-heroku.md). This is to prevent members of the public finding prototypes and thinking they are real services.
+
+You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately. 
 
 ## Installation instructions
 

--- a/docs/guides/publishing-on-heroku.md
+++ b/docs/guides/publishing-on-heroku.md
@@ -42,23 +42,13 @@ Replace `[name of your app]` with what you want to call your prototype.
 
 ## 5) Set a username and password
 
-By default, prototypes made with the kit require a username and password to be used when deployed on Heroku.
-
-Authentication is a good way to stop members of the public coming across your prototype by accident.
+Prototypes made with the kit require a username and password when published online. This stops members of the public coming across your prototype by accident.
 
 ### To set username and password:
 
 ```
 heroku config:set USERNAME=username_here
 heroku config:set PASSWORD=password_here
-```
-
-### Turning off authentication:
-
-If you want your prototype to be accessible on the web without needing a username and password, you can disable authentication.
-
-```
-heroku config:set USE_AUTH=false
 ```
 
 ## 6) Deploy your work


### PR DESCRIPTION
change security guidance to make username and password mandatory - to prevent members of the public finding prototypes and thinking they're real services