### PR TITLE
Adding browser-sync to the prototyping kit.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,7 @@ exports.basicAuth = function(username, password) {
 	};
 };
 
-exports.findAvailablePort = function(app){
+exports.findAvailablePort = function(app,callback){
 
   var port = null;
 
@@ -51,10 +51,7 @@ exports.findAvailablePort = function(app){
   portScanner.findAPortNotInUse(port, port+50, '127.0.0.1', function(error, availablePort) {
 
     if (port == availablePort){
-
-      app.listen(port);
-      console.log('Listening on port ' + port + '   url: http://localhost:' + port);
-
+      callback(port);
     } else {
 
       // Default port in use - offer to change to available port
@@ -79,9 +76,9 @@ exports.findAvailablePort = function(app){
           // User answers yes
           port = availablePort;
           fs.writeFileSync(__dirname+'/../.port.tmp', port);
-          app.listen(port);
           console.log('Changed to port ' + port + '   url: http://localhost:' + port);
 
+          callback(port);
         } else {
 
           // User answers no - exit

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ exports.findAvailablePort = function(app,callback){
           // User answers yes
           port = availablePort;
           fs.writeFileSync(__dirname+'/../.port.tmp', port);
-          console.log('Changed to port ' + port + '   url: http://localhost:' + port);
+          console.log('Changed to port ' + port);
 
           callback(port);
         } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,7 @@ exports.basicAuth = function(username, password) {
 	};
 };
 
-exports.findAvailablePort = function(app,callback){
+exports.findAvailablePort = function(app, callback){
 
   var port = null;
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
+    "browser-sync": "^2.11.1",
     "consolidate": "0.x",
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",

--- a/server.js
+++ b/server.js
@@ -132,15 +132,15 @@ console.log("\nNOTICE: the kit is for building prototypes, do not use it for pro
 
 // start the app
 utils.findAvailablePort(app, function(port) {
-  console.log('Listening on port ' + port + '     url: http://localhost:' + port);
+  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
   if (env === 'production') {
     app.listen(port);
   } else {
-    app.listen(port,function()
+    app.listen(port-50,function()
     {
       browserSync({
-        proxy:'localhost:' + port,
-        port:(port+1),
+        proxy:'localhost:'+(port-50),
+        port:port,
         ui:false,
         files:['public/**/*.*','app/views/**/*.*'],
         ghostmode:false,
@@ -148,7 +148,6 @@ utils.findAvailablePort(app, function(port) {
         notify:false,
         logLevel: "error"
       });
-      console.log("Browsersync on port " + (port+1) + "   url: http://localhost:" + (port+1) );
     });
   }
 });

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 var path = require('path'),
     express = require('express'),
+    browserSync = require('browser-sync'),
     nunjucks = require('express-nunjucks'),
     routes = require(__dirname + '/app/routes.js'),
     favicon = require('serve-favicon'),
@@ -130,4 +131,22 @@ console.log("\nGOV.UK Prototype kit v" + releaseVersion);
 console.log("\nNOTICE: the kit is for building prototypes, do not use it for production services.");
 
 // start the app
-utils.findAvailablePort(app);
+utils.findAvailablePort(app, function(port) {
+  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+  if (env === 'production') {
+    app.listen(port);
+  } else {
+    app.listen(port,function()
+    {
+      browserSync({
+        proxy:'localhost:'+port,
+        port:port+50,
+        ui:false,
+        files:['public/**/*.*','app/views/**/*.*'],
+        ghostmode:false,
+        open:false,
+        notify:false
+      });
+    });
+  }
+});

--- a/server.js
+++ b/server.js
@@ -132,7 +132,7 @@ console.log("\nNOTICE: the kit is for building prototypes, do not use it for pro
 
 // start the app
 utils.findAvailablePort(app, function(port) {
-  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+  console.log('Listening on port ' + (port+50) + '   url: http://localhost:' + (port+50));
   if (env === 'production') {
     app.listen(port);
   } else {
@@ -145,7 +145,8 @@ utils.findAvailablePort(app, function(port) {
         files:['public/**/*.*','app/views/**/*.*'],
         ghostmode:false,
         open:false,
-        notify:false
+        notify:false,
+        logLevel: "error"
       });
     });
   }

--- a/server.js
+++ b/server.js
@@ -132,15 +132,15 @@ console.log("\nNOTICE: the kit is for building prototypes, do not use it for pro
 
 // start the app
 utils.findAvailablePort(app, function(port) {
-  console.log('Listening on port ' + (port+50) + '   url: http://localhost:' + (port+50));
+  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
   if (env === 'production') {
     app.listen(port);
   } else {
-    app.listen(port,function()
+    app.listen(port-50,function()
     {
       browserSync({
-        proxy:'localhost:'+port,
-        port:port+50,
+        proxy:'localhost:'+(port-50),
+        port:port,
         ui:false,
         files:['public/**/*.*','app/views/**/*.*'],
         ghostmode:false,

--- a/server.js
+++ b/server.js
@@ -132,15 +132,15 @@ console.log("\nNOTICE: the kit is for building prototypes, do not use it for pro
 
 // start the app
 utils.findAvailablePort(app, function(port) {
-  console.log('Listening on port ' + port + '   url: http://localhost:' + port);
+  console.log('Listening on port ' + port + '     url: http://localhost:' + port);
   if (env === 'production') {
     app.listen(port);
   } else {
-    app.listen(port-50,function()
+    app.listen(port,function()
     {
       browserSync({
-        proxy:'localhost:'+(port-50),
-        port:port,
+        proxy:'localhost:' + port,
+        port:(port+1),
         ui:false,
         files:['public/**/*.*','app/views/**/*.*'],
         ghostmode:false,
@@ -148,6 +148,7 @@ utils.findAvailablePort(app, function(port) {
         notify:false,
         logLevel: "error"
       });
+      console.log("Browsersync on port " + (port+1) + "   url: http://localhost:" + (port+1) );
     });
   }
 });


### PR DESCRIPTION
This PR is to replace #144 and #149 but still in response to issue #84.

After discussion with @joelanman I've reverted to adding a callback to the `findAvailablePort` function and then start browser-sync in server.js (or not if in 'production'). I've also incorporated Joe's updated browser-sync config options into this new PR.

(Only tested on MacOSX 10.11.4 so far though)