### PR TITLE
Windows heroku login instructions

### DIFF
--- a/docs/guides/publishing-on-heroku.md
+++ b/docs/guides/publishing-on-heroku.md
@@ -1,7 +1,5 @@
 # Publishing on the web (Heroku)
 
-> These don't currently work on Windows due to a software incompatability. The Heroku toolbelt is not compatible with Git Bash - you will need to use CMD instead.
-
 We recommend using [Heroku](http://www.heroku.com) to get your prototype online. It’s simple and fast to deploy new versions as you work.
 
 Once your prototype is on Heroku, other people will be able to access and try your prototype from their own computers or mobile devices.
@@ -13,7 +11,6 @@ A prototype deployed on Heroku is called an `app` - it will have a url like:
 
 You can have multiple apps running on Heroku - projects often have several so they can try different ideas out at once.
 
-
 ## 1) Sign up to Heroku
 
 If you’re new to Heroku, [sign up for a free account](https://signup.heroku.com/). When asked what language you use, select `node.js`.
@@ -21,6 +18,8 @@ If you’re new to Heroku, [sign up for a free account](https://signup.heroku.co
 ## 2) Install the Heroku toolbelt.
 
 Install the [Heroku toolbelt](https://toolbelt.heroku.com/).
+
+> On Windows, after downloading the toolbelt you'll need to run `heroku login` using the `cmd` app, as it does not work in Git Bash. Once you've logged in, you can return to using Git Bash.
 
 The toolbelt lets you use Heroku through the terminal. You will need to restart the terminal after installing the toolbelt.
 


### PR DESCRIPTION
Make windows heroku instructions clearer, and move them to where you're more likely to need them.

Relates to this issue: https://github.com/heroku/cli/issues/84