### PR TITLE
add logging example page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -28,6 +28,27 @@ router.get('/examples/over-18', function (req, res) {
   }
 })
 
+router.get('/examples/logging-data', function (req, res) {
+
+  var users = {
+    "Alex": {
+      "age": 18,
+      "town": "London"
+    },
+    "Charlie": {
+      "age": 65,
+      "town": "Edinburgh"
+    },
+    "Sean": {
+      "age": 43,
+      "town": "Cardiff"
+    }
+  }
+
+  res.render('examples/logging-data', {users: users});
+
+});
+
 // add your routes here
 
 module.exports = router

--- a/app/routes.js
+++ b/app/routes.js
@@ -29,25 +29,23 @@ router.get('/examples/over-18', function (req, res) {
 })
 
 router.get('/examples/logging-data', function (req, res) {
-
   var users = {
-    "Alex": {
-      "age": 18,
-      "town": "London"
+    'Alex': {
+      'age': 18,
+      'town': 'London'
     },
-    "Charlie": {
-      "age": 65,
-      "town": "Edinburgh"
+    'Charlie': {
+      'age': 65,
+      'town': 'Edinburgh'
     },
-    "Sean": {
-      "age": 43,
-      "town": "Cardiff"
+    'Sean': {
+      'age': 43,
+      'town': 'Cardiff'
     }
   }
 
-  res.render('examples/logging-data', {users: users});
-
-});
+  res.render('examples/logging-data', {users: users})
+})
 
 // add your routes here
 

--- a/app/views/examples/index.html
+++ b/app/views/examples/index.html
@@ -107,6 +107,11 @@
           <p class="font-xsmall">(Showing a different page based on user input)</p>
         </li>
         <li>
+          <a href="/examples/logging-data">
+            Logging data
+          </a>
+        </li>
+        <li>
           <a href="/examples/template-partial-areas">
             Template partial areas
           </a>

--- a/app/views/examples/logging-data.html
+++ b/app/views/examples/logging-data.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Logging data
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        Logging data
+      </h1>
+
+      <p>You can send data to the browser console using the "log" filter in your template:</p>
+
+      {{ users | log }}
+
+      <p class="code">
+  {% raw %}{{ users | log }}{% endraw %}
+      </p>
+
+      <p>
+        Open the browser console to see the data in this example. In Chrome, press the <code class="code">cmd + alt + j</code> keys together to open the console.
+      </p>
+
+      <p>
+        This can be useful when using complex data in your prototype, to check it looks correct.
+      </p>
+
+    </div>
+  </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
Adds an example page for the `log` filter, which allows you to log any data on the page to the console.
