### PR TITLE
Use release 1.2.0 of the govuk-elements-sass package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",
     "express-writer": "0.0.4",
-    "govuk-elements-sass": "alphagov/govuk_elements#v1.1.1",
+    "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.12.0",
     "govuk_template_mustache": "^0.17.3",
     "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",


### PR DESCRIPTION
Use release 1.2.0 of the govuk-elements-sass package.