### PR TITLE
Use the govuk template jinja npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.12.0",
-    "govuk_template_jinja": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
+    "govuk_template_jinja": "0.17.3",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
The Jinja version of the GOV.UK template is now published to npm,
update package.json.