### PR TITLE
Use version 4.13.0 of the govuk frontend toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
-    "govuk_frontend_toolkit": "^4.12.0",
+    "govuk_frontend_toolkit": "^4.13.0",
     "govuk_template_jinja": "0.17.3",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
# 4.13.0

- Make headings block-level by default. If you are styling elements you
want to be inline with heading includes, you’ll need to explicitly make
them inline in your CSS.