### PR TITLE
Bump govuk frontend toolkit to 4.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
-    "govuk_frontend_toolkit": "^4.13.0",
+    "govuk_frontend_toolkit": "^4.14.1",
     "govuk_template_jinja": "0.17.3",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
# 4.14.1

- Fix tabular number sizing in Firefox ([PR
#301](https://github.com/alphagov/govuk_frontend_toolkit/pull/301))

# 4.14.0

- Allow use of multiple GA customDimensionIndex. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#using-google-custom-dimensions-with-your-own-statisti
cal-model) of the documentation for more information.
- Configurable duration (in days) for AB Test cookie. See [this
section](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/
docs/javascript.md#multivariate-test-framework) of the documentation
for more information.
- Allow base scripts to run within a module loader. See [this
PR](https://github.com/alphagov/govuk_frontend_toolkit/pull/290) for
more information.

https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/master
/CHANGELOG.md