### PR TITLE
Bump govuk template to 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.14.1",
-    "govuk_template_jinja": "0.17.3",
+    "govuk_template_jinja": "0.18.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
[0.18.0](https://raw.githubusercontent.com/alphagov/govuk_template/master/CHANGELOG.md)

- Publish the Jinja version of the template to NPM
- Update HTML5 Shiv to the latest version
- Remove an errant font loader script that was only being used for IE8

