### PR TITLE
Show the current release version on the index page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -10,8 +10,10 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-      <h1 class="heading-xlarge">The GOV.UK prototype kit</h1>
-
+      <h1 class="heading-xlarge">
+        <span class="heading-secondary">{{releaseVersion}}</span>
+        The GOV.UK prototype kit
+      </h1>
       <p>
         This kit lets you rapidly create HTML prototypes of GOV.UK services.
       </p>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -11,8 +11,8 @@
     <div class="column-two-thirds">
 
       <h1 class="heading-xlarge">
-        <span class="heading-secondary">{{releaseVersion}}</span>
         The GOV.UK prototype kit
+        <span class="heading-secondary">{{releaseVersion}}</span>
       </h1>
       <p>
         This kit lets you rapidly create HTML prototypes of GOV.UK services.


### PR DESCRIPTION
We already log this version to the console when the app is run and it is included in a comment
at the bottom of each page. 

Add the release version above the title on the index page.
This will also make it easy to see that the [kit when deployed to Heroku is up to date](http://govuk-prototype-kit.herokuapp.com/).

This fixes #121.