### PR TITLE
Bump govuk frontend toolkit to 4.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
-    "govuk_frontend_toolkit": "^4.14.1",
+    "govuk_frontend_toolkit": "^4.15.0",
     "govuk_template_jinja": "0.18.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
Use version [4.15.0](https://github.com/alphagov/govuk_frontend_toolkit/commit/620c7
fdb1eca75cfb7a8c076cafcf50852a85008) of the GOV.UK frontend toolkit.

- Add support for Google Analytics fieldsObject

- anchor-buttons.js: normalise keyboard behaviour between buttons and
links with a button role