### PR TITLE
Include the shim-links-with-button-role.js script from the govuk_frontend_toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -107,7 +107,7 @@ $(document).ready(function () {
 
   // Use GOV.UK shim-links-with-button-role.js to trigger a link styled to look like a button,
   // with role="button" when the space key is pressed.
-  GOVUK.shimLinksWithButtonRole.init();
+  GOVUK.shimLinksWithButtonRole.init()
 
   // Show and hide toggled content
   // Where .block-label uses the data-target attribute

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -105,6 +105,10 @@ $(document).ready(function () {
   var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']")
   new GOVUK.SelectionButtons($blockLabels) // eslint-disable-line
 
+  // Use GOV.UK shim-links-with-button-role.js to trigger a link styled to look like a button,
+  // with role="button" when the space key is pressed.
+  GOVUK.shimLinksWithButtonRole.init();
+
   // Show and hide toggled content
   // Where .block-label uses the data-target attribute
   var toggleContent = new ShowHideContent()

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -2,4 +2,5 @@
 <script src="/public/javascripts/details.polyfill.js"></script>
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>
+<script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 <script src="/public/javascripts/application.js"></script>


### PR DESCRIPTION
Include a script from the govuk frontend toolkit to shim anchors with
`role="button"` to be 'clicked' via the space key.

For context, here is the PR adding this script to the govuk_frontend_toolkit.
https://github.com/alphagov/govuk_frontend_toolkit/pull/297