### PR TITLE
Bump govuk_template_jinja to 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.15.0",
-    "govuk_template_jinja": "0.18.0",
+    "govuk_template_jinja": "0.18.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
https://github.com/alphagov/govuk_template/blob/master/CHANGELOG.md

Remove gov.uk prefix from relative links when printing (PR #234)
Fix a .visually-hidden bug on GOV.UK (PR #177)