### PR TITLE
Add warning to console about prototype kit usage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,15 @@
 /* global $ */
 /* global GOVUK */
 
+// Warn about using the kit in production
+if (
+  window.sessionStorage && window.sessionStorage.getItem('prototypeWarning') !== 'false' &&
+  window.console && window.console.info
+) {
+  window.console.info('GOV.UK Prototype Kit - do not use for production')
+  window.sessionStorage.setItem('prototypeWarning', true)
+}
+
 function ShowHideContent () {
   var self = this
 
@@ -65,6 +74,7 @@ function ShowHideContent () {
       }
     })
   }
+
   self.showHideCheckboxToggledContent = function () {
     $(".block-label input[type='checkbox']").each(function () {
       var $checkbox = $(this)


### PR DESCRIPTION
Add a warning that gets printed to the console on the client side about not using the kit for production.

I've set it to only show once per session (using sessionStorage). This should hopefully strike a balance between being visible enough and not being too annoying.

Based on suggestion from @nickcolley 

![screen shot 2016-08-17 at 12 31 52](https://cloud.githubusercontent.com/assets/2204224/17734829/9cc9d01a-6476-11e6-9652-70a21066ec7c.png)
