### PR TITLE
Update principles

### DIFF
--- a/docs/principles.md
+++ b/docs/principles.md
@@ -3,10 +3,9 @@
 The prototype kit:
 
 - is designed for prototyping, not for production code
-- is as simple as possible without teaching bad habits
 - requires minimal skills to get started: HTML, CSS
+- should be fully documented in a way that is accessible to the target audience
 - makes use of existing GOV.UK tools and templates; the [GOV.UK template](https://github.com/alphagov/govuk_template), [GOV.UK front end toolkit](https://github.com/alphagov/govuk_frontend_toolkit) and [GOV.UK elements](https://github.com/alphagov/govuk_elements)
 - allows for server-side code
 - can be extended - for example using NPM to install a module, access datastores, etc
 - makes it easy to share prototypes with others online
-- should be fully documented in a way that is accessible to the target audience


### PR DESCRIPTION
remove the line about teaching bad habits - prototyping is different to production code, so 'bad habits' is not a relevant concept

move 'should be fully documented in a way that is accessible to the target audience' up as it's a high priority we're currently not meeting