### PR TITLE
Use version 4.18.1 of the govuk_frontend_toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
-    "govuk_frontend_toolkit": "^4.18.0",
+    "govuk_frontend_toolkit": "^4.18.1",
     "govuk_template_jinja": "0.18.1",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
# 4.18.1

- Fix error in IE - remove trailing comma from shimLinksWithButtonRole
JavaScript ([PR
#323](https://github.com/alphagov/govuk_frontend_toolkit/pull/323)).