### PR TITLE
Bump govuk_template_jinja to 0.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.18.1",
-    "govuk_template_jinja": "0.18.1",
+    "govuk_template_jinja": "0.18.2",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
# 0.18.2

- Degrade gracefully when external JS can’t be loaded ([PR
#248](https://github.com/alphagov/govuk_template/pull/248))