### PR TITLE
Update the govuk_frontend_toolkit to 4.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
-    "govuk_frontend_toolkit": "^4.18.1",
+    "govuk_frontend_toolkit": "^4.18.2",
     "govuk_template_jinja": "0.18.2",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
- Remove unnecessary print font fallback that causes regression
downstream ([PR
#328](https://github.com/alphagov/govuk_frontend_toolkit/pull/328))