### PR TITLE
Make css output easier to debug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,14 +4,14 @@ module.exports = function (grunt) {
     sass: {
       dev: {
         options: {
-          style: 'expanded',
-          sourcemap: true,
           includePaths: [
             'govuk_modules/govuk_template/assets/stylesheets',
             'govuk_modules/govuk_frontend_toolkit/stylesheets',
             'govuk_modules/govuk-elements-sass/'
           ],
-          outputStyle: 'expanded'
+          outputStyle: 'expanded',
+          sourceComments: true,
+          sourceMap: true
         },
         files: [{
           expand: true,


### PR DESCRIPTION
The generated css will now include source comments which show where in 
your sass files each css block comes from.

Also tidied up the options block:

- The `style` option is not supported by grunt-sass (`outputStyle` is the  correct option)
- `sourceMap` was misspelt and wasn’t generating the source maps
- The options have been arranged in alphabetical order to make it easier 
to read

Example source comments:

```css
/* line 18, govuk_modules/govuk_frontend_toolkit/stylesheets/_grid_layout.scss */
#content {
  max-width: 960px;
  margin: 0 15px;
}

@media (min-width: 641px) {
  /* line 18, govuk_modules/govuk_frontend_toolkit/stylesheets/_grid_layout.scss */
  #content {
    margin: 0 30px;
  }
}
```