### PR TITLE
Bump govuk_template to 0.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.18.2",
-    "govuk_template_jinja": "0.18.2",
+    "govuk_template_jinja": "0.18.3",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-concurrent": "0.4.3",


### PR DESCRIPTION
Logo fixes: Fix logo breaking layout when increasing font size, fix
invalid or non-standard CSS and remove obsolete CSS around logo, adjust
logo dimensions slightly (PR #237)