### PR TITLE
Bump govuk_frontend_toolkit to 4.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "2.0.0",
-    "govuk_frontend_toolkit": "^4.18.2",
+    "govuk_frontend_toolkit": "^4.18.3",
     "govuk_template_jinja": "0.18.3",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
# 4.18.3

- For smaller screens (<768px) ensure that the
GOVUK.StickAtTopWhenScrolling JS "unsticks" the element which was
previously "stuck" (by removing both the class which sets fixed
positioning and the shim). ([PR
#329](https://github.com/alphagov/govuk_frontend_toolkit/pull/329))