### PR TITLE
Remove duplicate JS,  that now exists in the govuk_frontend_toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,105 +10,6 @@ if (
   window.sessionStorage.setItem('prototypeWarning', true)
 }
 
-function ShowHideContent () {
-  var self = this
-
-  self.escapeElementName = function (str) {
-    var result = str.replace('[', '\\[').replace(']', '\\]')
-    return (result)
-  }
-
-  self.showHideRadioToggledContent = function () {
-    $(".block-label input[type='radio']").each(function () {
-      var $radio = $(this)
-      var $radioGroupName = $radio.attr('name')
-      var $radioLabel = $radio.parent('label')
-
-      var dataTarget = $radioLabel.attr('data-target')
-
-      // Add ARIA attributes
-
-      // If the data-target attribute is defined
-      if (dataTarget) {
-        // Set aria-controls
-        $radio.attr('aria-controls', dataTarget)
-
-        $radio.on('click', function () {
-          // Select radio buttons in the same group
-          $radio.closest('form').find('.block-label input[name=' + self.escapeElementName($radioGroupName) + ']').each(function () {
-            var $this = $(this)
-
-            var groupDataTarget = $this.parent('label').attr('data-target')
-            var $groupDataTarget = $('#' + groupDataTarget)
-
-            // Hide toggled content
-            $groupDataTarget.addClass('js-hidden')
-            // Set aria-expanded and aria-hidden for hidden content
-            $this.attr('aria-expanded', 'false')
-            $groupDataTarget.attr('aria-hidden', 'true')
-          })
-
-          var $dataTarget = $('#' + dataTarget)
-          $dataTarget.removeClass('js-hidden')
-          // Set aria-expanded and aria-hidden for clicked radio
-          $radio.attr('aria-expanded', 'true')
-          $dataTarget.attr('aria-hidden', 'false')
-        })
-      } else {
-        // If the data-target attribute is undefined for a radio button,
-        // hide visible data-target content for radio buttons in the same group
-
-        $radio.on('click', function () {
-          // Select radio buttons in the same group
-          $('.block-label input[name=' + self.escapeElementName($radioGroupName) + ']').each(function () {
-            var groupDataTarget = $(this).parent('label').attr('data-target')
-            var $groupDataTarget = $('#' + groupDataTarget)
-
-            // Hide toggled content
-            $groupDataTarget.addClass('js-hidden')
-            // Set aria-expanded and aria-hidden for hidden content
-            $(this).attr('aria-expanded', 'false')
-            $groupDataTarget.attr('aria-hidden', 'true')
-          })
-        })
-      }
-    })
-  }
-
-  self.showHideCheckboxToggledContent = function () {
-    $(".block-label input[type='checkbox']").each(function () {
-      var $checkbox = $(this)
-      var $checkboxLabel = $(this).parent()
-
-      var $dataTarget = $checkboxLabel.attr('data-target')
-
-      // Add ARIA attributes
-
-      // If the data-target attribute is defined
-      if (typeof $dataTarget !== 'undefined' && $dataTarget !== false) {
-        // Set aria-controls
-        $checkbox.attr('aria-controls', $dataTarget)
-
-        // Set aria-expanded and aria-hidden
-        $checkbox.attr('aria-expanded', 'false')
-        $('#' + $dataTarget).attr('aria-hidden', 'true')
-
-        // For checkboxes revealing hidden content
-        $checkbox.on('click', function () {
-          var state = $(this).attr('aria-expanded') === 'false'
-
-          // Toggle hidden content
-          $('#' + $dataTarget).toggleClass('js-hidden')
-
-          // Update aria-expanded and aria-hidden attributes
-          $(this).attr('aria-expanded', state)
-          $('#' + $dataTarget).attr('aria-hidden', !state)
-        })
-      }
-    })
-  }
-}
-
 $(document).ready(function () {
   // Use GOV.UK selection-buttons.js to set selected
   // and focused states for block labels
@@ -121,7 +22,7 @@ $(document).ready(function () {
 
   // Show and hide toggled content
   // Where .block-label uses the data-target attribute
-  var toggleContent = new ShowHideContent()
-  toggleContent.showHideRadioToggledContent()
-  toggleContent.showHideCheckboxToggledContent()
+  // to toggle hidden content
+  var showHideContent = new GOVUK.ShowHideContent()
+  showHideContent.init()
 })

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -3,4 +3,5 @@
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>
 <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
+<script src="/public/javascripts/govuk/show-hide-content.js"></script>
 <script src="/public/javascripts/application.js"></script>


### PR DESCRIPTION
Remove the ShowHideContent function, instead replace with
GOVUK.ShowHideContent JS.

GOVUK.ShowHideContent was added to the [govuk_frontend_toolkit in v4.18.0](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md#4180)