### PR TITLE
Setting up a very simple test suite to check the server and build tasks run across nodejs 4, 5 & 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: node_js
 node_js:
-- 4.0
+- "4"
+- "5"
+- "6"
 before_install:
 - npm install -g grunt-cli
+- npm install -g mocha
 install:
 - npm install
 script:
-- "./node_modules/grunt-cli/bin/grunt test"
 - npm test
 after_success:
 - "./create-release-tag.sh"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,12 +137,4 @@ module.exports = function (grunt) {
     'generate-assets',
     'concurrent:target'
   ])
-
-  grunt.registerTask(
-    'test',
-    'default',
-    function () {
-      grunt.log.writeln('Test that the app runs')
-    }
-  )
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node start.js",
     "lint": "standard",
-    "test": "npm run lint"
+    "test": "mocha && npm run lint"
   },
   "dependencies": {
     "basic-auth": "^1.0.3",
@@ -40,5 +40,8 @@
     "serve-favicon": "2.3.0",
     "standard": "^7.1.2",
     "sync-request": "^3.0.1"
+  },
+  "devDependencies": {
+    "supertest": "^2.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -206,3 +206,5 @@ utils.findAvailablePort(app, function (port) {
     })
   }
 })
+
+module.exports = app

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive

--- a/test/spec/sanity-checks.js
+++ b/test/spec/sanity-checks.js
@@ -1,0 +1,34 @@
+/* global describe, it, before */
+var request = require('supertest')
+var assert = require('assert')
+var path = require('path')
+var fs = require('fs')
+
+/**
+ * Basic sanity checks on the dev server
+ */
+describe('The prototype kit', function () {
+  var app
+
+  before(function (done) {
+    require('grunt').tasks(['generate-assets'], {}, function () {
+      app = require('../../server')
+      done()
+    })
+  })
+
+  it('should generate assets into the /public folder', function () {
+    assert.doesNotThrow(function () {
+      fs.accessSync(path.resolve(__dirname, '../../public/javascripts/application.js'))
+      fs.accessSync(path.resolve(__dirname, '../../public/images/favicon.ico'))
+      fs.accessSync(path.resolve(__dirname, '../../public/stylesheets/application.css'))
+    })
+  })
+
+  it('should send with a well formed response for the index page', function (done) {
+    request(app)
+      .get('/')
+      .expect('Content-Type', /text\/html/)
+      .expect(200, done)
+  })
+})


### PR DESCRIPTION
The current test in `grunt test` doesn't actually _test_ anything apart from that the gruntfile can be parsed without error. It doesn't run the build or start the server. This PR introduces a very simple test suite that does a sanity check on the build output and makes a simple request to the express server to check it is up. It extends the travis config to run the test on nodejs 4, 5 and 6 which should allow you to catch any accidental use of anything too new.

_I note that there is a push to convert to gulp - this PR relies on grunt so it will need a little tweak if gulp gets merged first._
