### PR TITLE
Updating the link to the 'Publishing on Heroku' docs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
       console.log('Username or password is not set.')
-      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/guides/publishing-on-heroku.md#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
+      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/documentation/publishing-on-heroku.md#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
     }
 
     var user = basicAuth(req)


### PR DESCRIPTION
The error page that's displayed when you don't provide a heroku username and password goes to a 404 page. This PR updates that link.