### PR TITLE
Fix broken link and link to deployed docs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
       console.log('Username or password is not set.')
-      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/documentation/publishing-on-heroku.md#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
+      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
     }
 
     var user = basicAuth(req)


### PR DESCRIPTION
Fixes the link to guidance to setting username and password and instead links to the deployed docs on heroku.