### PR TITLE
Bump govuk frontend toolkit to 4.18.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "2.0.0",
-    "govuk_frontend_toolkit": "^4.18.3",
+    "govuk_frontend_toolkit": "^4.18.4",
     "govuk_template_jinja": "0.18.3",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
Bump govuk_frontend_toolkit to 4.18.4
# 4.18.4

https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/master
/CHANGELOG.md

- Lint codebase using standard
- Add semicolons at the start of IIFE's