### PR TITLE
Check for node_modules in start.js then run gulp - with logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0 <6.7"
   },
   "scripts": {
-    "start": "if [ -d \"node_modules\" ]; then gulp; else echo 'gulp is missing - try running npm install' ; fi",
+    "start": "node start.js",
     "lint": "standard",
     "test": "npm run lint"
   },
@@ -16,6 +16,7 @@
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
+    "chalk": "^1.1.3",
     "consolidate": "0.x",
     "express": "4.13.3",
     "express-session": "^1.13.0",
@@ -34,6 +35,7 @@
     "minimist": "0.0.8",
     "nunjucks": "^2.4.2",
     "portscanner": "^1.0.0",
+    "pretty-hrtime": "^1.0.2",
     "prompt": "^0.2.14",
     "readdir": "0.0.6",
     "require-dir": "^0.3.0",

--- a/start.js
+++ b/start.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+if (!fs.existsSync(path.join(__dirname, '/node_modules'))) {
+  console.log('node modules are missing, run npm install')
+  process.exit(0)
+}
+
+const gulp = require('gulp')
+const gutil = require('gulp-util')
+const chalk = require('chalk')
+const prettyTime = require('pretty-hrtime')
+require(path.join(__dirname, '/gulpfile.js'))
+
+// we need to set up logging for gulp
+// all copied from https://github.com/gulpjs/gulp/blob/master/bin/gulp.js
+
+// Format orchestrator errors
+function formatError (e) {
+  if (!e.err) {
+    return e.message
+  }
+
+  // PluginError
+  if (typeof e.err.showStack === 'boolean') {
+    return e.err.toString()
+  }
+
+  // Normal error
+  if (e.err.stack) {
+    return e.err.stack
+  }
+
+  // Unknown (string, number, etc.)
+  return new Error(String(e.err)).stack
+}
+
+gulp.on('task_start', function (e) {
+  // TODO: batch these
+  // so when 5 tasks start at once it only logs one time with all 5
+  gutil.log('Starting', '\'' + chalk.cyan(e.task) + '\'...')
+})
+
+gulp.on('task_stop', function (e) {
+  var time = prettyTime(e.hrDuration)
+  gutil.log(
+    'Finished', '\'' + chalk.cyan(e.task) + '\'',
+    'after', chalk.magenta(time)
+  )
+})
+
+gulp.on('task_err', function (e) {
+  var msg = formatError(e)
+  var time = prettyTime(e.hrDuration)
+  gutil.log(
+    '\'' + chalk.cyan(e.task) + '\'',
+    chalk.red('errored after'),
+    chalk.magenta(time)
+  )
+  gutil.log(msg)
+})
+
+gulp.on('task_not_found', function (err) {
+  gutil.log(
+    chalk.red('Task \'' + err.task + '\' is not in your gulpfile')
+  )
+  gutil.log('Please check the documentation for proper gulpfile formatting')
+  process.exit(1)
+})
+
+gulp.start('default')


### PR DESCRIPTION
this fixes #300 

the kit now works the same way it did with Grunt - start.js checks for node_modules, then runs gulp. The only difference is we have to add logging to gulp. In gulp this is done by the command line app. I've copied and pasted the code they use.

It'd be really useful if the logging was made available by gulp so it can be used programmatically in exactly the same way as from the command line.
