### PR TITLE
Remove external links: bump govuk_frontend_toolkit to 5.0.0 and govuk_template to 0.19.0 and govuk_elements_sass to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "2.0.0",
     "govuk_frontend_toolkit": "^5.0.0",
-    "govuk_template_jinja": "0.18.3",
+    "govuk_template_jinja": "0.19.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-nodemon": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "4.13.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
-    "govuk-elements-sass": "2.0.0",
+    "govuk-elements-sass": "2.1.0",
     "govuk_frontend_toolkit": "^5.0.0",
     "govuk_template_jinja": "0.19.0",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "2.0.0",
-    "govuk_frontend_toolkit": "^4.18.4",
+    "govuk_frontend_toolkit": "^5.0.0",
     "govuk_template_jinja": "0.18.3",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
### Bump [govuk_frontend_toolkit to 5.0.0](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md)

This release includes two breaking changes:

- Removal of external link styles and icons, if you are using the external-link-* mixins you will need to remove them from your codebase  ([PR #293](https://github.com/alphagov/govuk_frontend_toolkit/pull/293))
- Correct spelling of the 'accordion' icon, you will need to check for the incorrect spelling 'accordian' and update if you are using this icon ([PR #345](https://github.com/alphagov/govuk_frontend_toolkit/pull/345))

And two minor changes:

- Amend GOVUK.StickAtTopWhenScrolling to resize the sticky element and shim when the .js-sticky-resize class is set ([PR #343](https://github.com/alphagov/govuk_frontend_toolkit/pull/343))
- Allow custom options in GOVUK.analytics.trackPageview ([#332](https://github.com/alphagov/govuk_frontend_toolkit/pull/332))

-----


### Bump [govuk_template_jinja to 0.19.0](https://github.com/alphagov/govuk_template/blob/master/CHANGELOG.md)

- Remove external link styles (PR #231)
- Remove extraneous copy of HTML5shiv that wasn’t being used (PR #254)
- Update govuk_frontend_toolkit to latest version (PR #256)

----

### Bump [govuk-elements-sass to 2.1.0](https://github.com/alphagov/govuk_elements/blob/master/CHANGELOG.md)

- Clear floats on details elements (PR #328)
- Add a .bold utility class (PR #321)
- Remove external link styles (PR #274)
