### PR TITLE
Run gulp as child process with logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.0 <6.7"
   },
   "scripts": {
-    "start": "if [ -d \"node_modules\" ]; then gulp; else echo 'gulp is missing - try running npm install' ; fi",
+    "start": "node start.js",
     "lint": "standard",
     "test": "npm run lint"
   },

--- a/start.js
+++ b/start.js
@@ -1,0 +1,23 @@
+// Check for `node_modules` folder and warn if missing
+
+var path = require('path')
+var fs = require('fs')
+
+if (!fs.existsSync(path.join(__dirname, '/node_modules'))) {
+  console.error('ERROR: Node module folder missing. Try running `npm install`')
+  process.exit(0)
+}
+
+// run gulp
+
+var child = require('child_process')
+
+process.env['FORCE_COLOR'] = 1
+var gulp = child.spawn('gulp')
+gulp.stdout.pipe(process.stdout)
+gulp.stderr.pipe(process.stderr)
+process.stdin.pipe(gulp.stdin)
+
+gulp.on('exit', function (code) {
+  console.log('gulp exited with code ' + code.toString())
+})


### PR DESCRIPTION
This means:

 - node_modules check runs correctly regardless of OS, because its done in Node
 - gulp logs correctly
 - we dont copy and paste lots of code from gulp in order for it to log correctly
 - nothing else is broken (crosses fingers)