### PR TITLE
use cross-spawn to fix spawn on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "consolidate": "0.x",
+    "cross-spawn": "^5.0.0",
     "express": "4.13.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",

--- a/start.js
+++ b/start.js
@@ -10,10 +10,10 @@ if (!fs.existsSync(path.join(__dirname, '/node_modules'))) {
 
 // run gulp
 
-var child = require('child_process')
+var spawn = require('cross-spawn')
 
 process.env['FORCE_COLOR'] = 1
-var gulp = child.spawn('gulp')
+var gulp = spawn('gulp')
 gulp.stdout.pipe(process.stdout)
 gulp.stderr.pipe(process.stderr)
 process.stdin.pipe(gulp.stdin)


### PR DESCRIPTION
child.spawn has problems on windows, the cross spawn npm package fixes these