### PR TITLE
Update readme to point to docs app

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,6 @@
-# Installation guide
-
-Installation guide for new users (non technical):
-
-1. [Introduction](install/introduction.md)
-2. [Requirements](install/requirements.md)
-3. [Install the kit](install/install-the-kit.md)
-4. [Run the kit](install/run-the-kit.md)
-
-Installation guide for developers (technical):
-
-[Developer install instructions](developer-install-instructions.md)
-
-# Guides
-
-1. [Setting up git](guides/setting-up-git.md)
-1. [Publishing on the web (Heroku)](guides/publishing-on-heroku.md)
-
 # Documentation
 
-- [Prototype kit principles](principles.md)
-- [Making pages](making-pages.md)
-- [Writing CSS](writing-css.md)
-- [Updating the kit to the latest version](updating-the-kit.md)
-- [Tips and tricks](tips-and-tricks.md)
-- [Creating routes (server-side programming)](creating-routes.md)
-- [Storing data in session](session.md)
+[Documentation and examples](https://govuk-prototype-kit.herokuapp.com/docs)
+
+Documentation is also available when running the app locally at http:localhost:3000/docs
+


### PR DESCRIPTION
The current readme is out of date and links to 404s.

Instead link to the documentation app.