### PR TITLE
Remove console log for the file path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -171,8 +171,6 @@ exports.matchRoutes = function (req, res) {
 
 exports.matchMdRoutes = function (req, res) {
   var docsPath = '/../docs/documentation/'
-  var filePath = path.join(__dirname, docsPath, req.params[0] + '.md')
-  console.log('file path is:', filePath)
   if (fs.existsSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')) {
     var doc = fs.readFileSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')
     var html = marked(doc)


### PR DESCRIPTION
This can be seen when viewing the docs app locally:

`http://localhost:3000/docs`

```
file path is: /govuk_prototype_kit/docs/documentation/making-pages.md
file path is: /govuk_prototype_kit/docs/documentation/setting-up-git.md
```

This was added to debug the links to markdown files in the documentation app, remove these lines.