### PR TITLE
Google analytics local fix - only run in promo mode

### DIFF
--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -1,13 +1,17 @@
 <link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="/public/stylesheets/docs.css" media="screen" rel="stylesheet" type="text/css" />
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+{% if promoMode == 'true' %}
 
-  ga('create', 'UA-26179049-11', 'auto');
-  ga('send', 'pageview');
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-</script>
+    ga('create', 'UA-26179049-11', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+
+{% endif %}

--- a/server.js
+++ b/server.js
@@ -106,6 +106,7 @@ app.use(function (req, res, next) {
   res.locals.serviceName = config.serviceName
   res.locals.cookieText = config.cookieText
   res.locals.releaseVersion = 'v' + releaseVersion
+  res.locals.promoMode = promoMode
   next()
 })
 


### PR DESCRIPTION
currently the google analytics code runs locally, which is not correct. This PR uses the promoMode variable to ensure it only runs when in promoMode (on heroku)