### PR TITLE
Make analytics non-deploy specific

### DIFF
--- a/docs/views/includes/analytics.html
+++ b/docs/views/includes/analytics.html
@@ -1,0 +1,9 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ analyticsId }}', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -1,13 +1,17 @@
 <link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="/public/stylesheets/docs.css" media="screen" rel="stylesheet" type="text/css" />
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+{% if promoMode == 'true' %}
 
-  ga('create', 'UA-26179049-11', 'auto');
-  ga('send', 'pageview');
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-</script>
+    ga('create', 'UA-26179049-11', 'auto');
+    ga('send', 'pageview');
+
+  </script>
+
+{% endif %}

--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -1,17 +1,6 @@
 <link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
 <link href="/public/stylesheets/docs.css" media="screen" rel="stylesheet" type="text/css" />
 
-{% if promoMode == 'true' %}
-
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-26179049-11', 'auto');
-    ga('send', 'pageview');
-
-  </script>
-
+{% if promoMode == 'true' and analyticsId %}
+	{% include "includes/analytics.html" %}
 {% endif %}

--- a/server.js
+++ b/server.js
@@ -106,6 +106,7 @@ app.use(function (req, res, next) {
   res.locals.serviceName = config.serviceName
   res.locals.cookieText = config.cookieText
   res.locals.releaseVersion = 'v' + releaseVersion
+  res.locals.promoMode = promoMode
   next()
 })
 

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ var password = process.env.PASSWORD
 var env = process.env.NODE_ENV || 'development'
 var useAuth = process.env.USE_AUTH || config.useAuth
 var useHttps = process.env.USE_HTTPS || config.useHttps
+var analyticsId = process.env.ANALYTICS_TRACKING_ID
 
 env = env.toLowerCase()
 useAuth = useAuth.toLowerCase()
@@ -103,6 +104,7 @@ app.use(function (req, res, next) {
 
 // Add variables that are available in all views
 app.use(function (req, res, next) {
+  res.locals.analyticsId = analyticsId
   res.locals.serviceName = config.serviceName
   res.locals.cookieText = config.cookieText
   res.locals.releaseVersion = 'v' + releaseVersion


### PR DESCRIPTION
This pr amends #320 and works on #322 so that tracking code tied to the app. We don't want other users of the kit to use our tracking code - they should use their own if they want tracking.

Since tracking codes are deploy specific, it's better if it comes from environment.

This pr:
* Moves tracking snippet to an include
* Pulls a tracking code out of env
* Only sets tracking code if it exists