### PR TITLE
Bump govuk-elements-sass to 2.2.1

### DIFF
--- a/app/views/includes/phase_banner_alpha.html
+++ b/app/views/includes/phase_banner_alpha.html
@@ -1,4 +1,4 @@
-<div class="phase-banner-alpha">
+<div class="phase-banner">
   <p>
     <strong class="phase-tag">ALPHA</strong>
     <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>

--- a/app/views/includes/phase_banner_beta.html
+++ b/app/views/includes/phase_banner_beta.html
@@ -1,4 +1,4 @@
-<div class="phase-banner-beta">
+<div class="phase-banner">
   <p>
     <strong class="phase-tag">BETA</strong>
     <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "4.13.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
-    "govuk-elements-sass": "2.2.0",
+    "govuk-elements-sass": "2.2.1",
     "govuk_frontend_toolkit": "^5.0.1",
     "govuk_template_jinja": "0.19.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
This makes the phase tag in the phase banner `$govuk-blue`.

As the phase banner is now the same for both alpha and beta banners,
change the phase banner includes to use the recommended class
`.phase-banner`.

(This will fail until the PR for govuk_elements bumping the version to 2.2.1 is merged).