### PR TITLE
Set travis to update the latest release branch after deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
 - npm test
 after_success:
 - "./create-release-tag.sh"
+after_deploy:
 - "./update-release-branch.sh"
 deploy:
   provider: heroku


### PR DESCRIPTION
It looks like Travis is deploying the latest-release branch to Heroku.

Let’s move the script that checks for a version tag to after_deploy, in
the hope that it won’t interfere with the deployment of master to Heroku on a
successful build.