### PR TITLE
Auto data session 4

### DIFF
--- a/app/assets/javascripts/auto-store-data.js
+++ b/app/assets/javascripts/auto-store-data.js
@@ -1,0 +1,26 @@
+/* global $ */
+$('body').on('submit', 'form', function (e) {
+  // On form submit, add hidden inputs for checkboxes so the server knows if
+  // they've been unchecked. This means we can automatically store and update
+  // all form data on the server, including checkboxes that are checked, then
+  // later unchecked
+
+  var $checkboxes = $(this).find('input:checkbox')
+
+  var $inputs = []
+  var names = {}
+
+  $checkboxes.each(function () {
+    var $this = $(this)
+
+    if (!names[$this.attr('name')]) {
+      names[$this.attr('name')] = true
+      var $input = $('<input type="hidden">')
+      $input.attr('name', $this.attr('name'))
+      $input.attr('value', '_unchecked')
+      $inputs.push($input)
+    }
+  })
+
+  $(this).prepend($inputs)
+})

--- a/app/config.js
+++ b/app/config.js
@@ -12,6 +12,9 @@ module.exports = {
   // Enable or disable password protection on production
   useAuth: 'true',
 
+  // Automatically stores form data, and send to all views
+  useAutoStoreData: 'true',
+
   // Enable or disable built-in docs and examples.
   useDocumentation: 'true',
 

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -4,3 +4,7 @@
 <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 <script src="/public/javascripts/govuk/show-hide-content.js"></script>
 <script src="/public/javascripts/application.js"></script>
+
+{% if useAutoStoreData %}
+  <script src="/public/javascripts/auto-store-data.js"></script>
+{% endif %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -36,6 +36,16 @@
   with-proposition
 {% endblock %}
 
+{% block footer_support_links %}
+  {% if useAutoStoreData %}
+    <ul>
+      <li>
+        <a href="/prototype-admin/clear-data">Clear data</a>
+      </li>
+    </ul>
+  {% endif %}
+{% endblock %}
+
 {% block body_end %}
   {% include "includes/scripts.html" %}
   <!-- GOV.UK Prototype kit {{releaseVersion}} -->

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -1,0 +1,58 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Passing data
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        Passing data from page to page
+      </h1>
+
+      <p>
+        You may want to use or display data a user has entered over a few screens. The kit automatically stores all data entered, so you can show it later.
+      </p>
+
+      <p>
+        To clear the data (for example at the end of a user research session) click the "Clear data" link in the footer.
+      </p>
+
+      <p>
+        You can see the code for this example here:
+      </p>
+
+      <pre>
+<div class="code">
+  /app/views/examples/pass-data
+
+</div>
+      </pre>
+
+      <form action="/docs/examples/pass-data/vehicle-type" method="post" class="form">
+
+        <div class="form-group">
+          <fieldset>
+
+            <label class="form-label" for="registration-number">Vehicle registration number</label>
+            <input class="form-control" id="registration-number" name="vehicleRegistration" type="text" value="{{vehicleRegistration}}">
+
+          </fieldset>
+        </div>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue">
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -25,32 +25,76 @@
       </p>
 
       <p>
-        You can see the code for this example here:
+        <a href="/docs/examples/pass-data/vehicle-registration">You can see an example here.</a>
+      </p>
+
+      <p>
+        The code for the example is in this folder in the prototype kit:
       </p>
 
       <pre>
 <div class="code">
-  /app/views/examples/pass-data
+  /docs/views/examples/pass-data
 
 </div>
       </pre>
 
-      <form action="/docs/examples/pass-data/vehicle-type" method="post" class="form">
+      <h2 class="heading-medium">How to use</h2>
 
-        <div class="form-group">
-          <fieldset>
+      <p>The kit stores data from inputs using the name attribute of the input.</p>
 
-            <label class="form-label" for="registration-number">Vehicle registration number</label>
-            <input class="form-control" id="registration-number" name="vehicle-registration" type="text" value="{{data['vehicle-registration']}}">
+      <p>For example, if you have this input:</p>
 
-          </fieldset>
-        </div>
+      <pre>
+<div class="code">
+  &lt;input name="first-name"&gt;
 
-        <div class="form-group">
-          <input type="submit" class="button" value="Continue">
-        </div>
+</div>
+      </pre>
 
-      </form>
+      <p>You can show what the user entered later on like this:</p>
+
+      <pre>
+<div class="code">
+  &lt;p&gt;{%raw%}{{ data['first-name'] }}{%endraw%}&lt;/p&gt;
+
+</div>
+      </pre>
+
+      <h3 class="heading-small">
+        Setting inputs
+      </h3>
+
+      <p>
+        If a user goes back to a page where they entered data, they would expect to see the answer they gave.
+      </p>
+
+      <p>For a text input:</p>
+      <pre>
+<div class="code">
+  &lt;input name="first-name" value="{%raw%}{{ data['first-name'] }}{%endraw%}"&gt;
+
+</div>
+      </pre>
+
+      <p>For a radio or checkbox input you need to use the 'checked' function:</p>
+      <pre>
+<div class="code">
+  &lt;input type="radio" name="over-18" value="yes" {%raw%}{{ checked('over-18','yes') }}{%endraw%}&gt;
+
+</div>
+      </pre>
+
+      <h2 class="heading-small">Server-side (advanced)</h2>
+
+      <p>You can access the data on the server in a route, for example for an input with name="first-name":</p>
+
+      <pre>
+<div class="code">
+  var firstName = req.session.data['first-name']
+
+</div>
+      </pre>
 
     </div>
   </div>

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -41,7 +41,7 @@
           <fieldset>
 
             <label class="form-label" for="registration-number">Vehicle registration number</label>
-            <input class="form-control" id="registration-number" name="vehicleRegistration" type="text" value="{{vehicleRegistration}}">
+            <input class="form-control" id="registration-number" name="vehicle-registration" type="text" value="{{data['vehicle-registration']}}">
 
           </fieldset>
         </div>

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -61,8 +61,17 @@
 </div>
       </pre>
 
+
       <h3 class="heading-small">
-        Setting inputs
+        Clearing data
+      </h3>
+
+      <p>
+        To clear the data (for example at the end of a user research session) click the "Clear data" link in the footer.
+      </p>
+
+      <h3 class="heading-small">
+        Showing answers in inputs
       </h3>
 
       <p>
@@ -85,13 +94,30 @@
 </div>
       </pre>
 
-      <h2 class="heading-small">Server-side (advanced)</h2>
+      <h2 class="heading-medium">Advanced features</h2>
+
+      <h3 class="heading-small">
+        Using the data on the server
+      </h3>
 
       <p>You can access the data on the server in a route, for example for an input with name="first-name":</p>
 
       <pre>
 <div class="code">
   var firstName = req.session.data['first-name']
+
+</div>
+      </pre>
+
+      <h3 class="heading-small">
+        Ignoring inputs
+      </h3>
+
+      <p>To prevent an input being stored, use an underscore at the start of the name.</p>
+
+      <pre>
+<div class="code">
+  &lt;input name="_secret"&gt;
 
 </div>
       </pre>

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -1,0 +1,105 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Check your answers
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Check your answers before sending your application
+      </h1>
+
+      <p>
+        When a user has entered data on pages, show it by using code like this:
+      </p>
+
+      <pre>
+        <div class="code">{% raw %}
+  &lt;tr&gt;
+    &lt;td&gt;
+      Vehicle type:
+    &lt;/td&gt;
+    &lt;td&gt;
+      {{vehicleType}}
+    &lt;/td&gt;
+  &lt;/tr&gt;
+  {% endraw %}</div></pre>
+    </div>
+  </div>
+
+  <div class="form-group">
+
+    <table class="check-your-answers">
+
+      <thead>
+        <tr>
+          <th colspan="2">
+            <h2 class="heading-medium">
+              Vehicle details
+            </h2>
+          </th>
+          <th>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Registration number
+          </td>
+          <td>
+            {{vehicleRegistration}}
+          </td>
+          <td class="change-answer">
+            <a href="/docs/examples/pass-data/">
+              Change <span class="visuallyhidden">registration number</span>
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Vehicle type
+          </td>
+          <td>
+            {{vehicleType}}
+          </td>
+          <td class="change-answer">
+            <a href="/docs/examples/pass-data/vehicle-type">
+              Change <span class="visuallyhidden">vehicle type</span>
+            </a>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Vehicle features
+          </td>
+          <td>
+            {{vehicleFeatures}}
+          </td>
+          <td class="change-answer">
+            <a href="/docs/examples/pass-data/vehicle-features">
+              Change <span class="visuallyhidden">vehicle features</span>
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="form-group">
+    <p>
+      <a href="/docs/examples">
+        Return to prototype kit examples
+      </a>
+    </p>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -25,7 +25,7 @@
       Vehicle type:
     &lt;/td&gt;
     &lt;td&gt;
-      {{data['vehicleType']}}
+      {{data['vehicle-type']}}
     &lt;/td&gt;
   &lt;/tr&gt;
   {% endraw %}</div></pre>
@@ -54,7 +54,7 @@
             Registration number
           </td>
           <td>
-            {{data['vehicleRegistration']}}
+            {{data['vehicle-registration']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/">
@@ -67,7 +67,7 @@
             Vehicle type
           </td>
           <td>
-            {{data['vehicleType']}}
+            {{data['vehicle-type']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/vehicle-type">
@@ -80,7 +80,7 @@
             Vehicle features
           </td>
           <td>
-            {{data['vehicleFeatures']}}
+            {{data['vehicle-features']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/vehicle-features">

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block page_title %}
-  Check your answers
+Check your answers
 {% endblock %}
 
 {% block content %}
@@ -14,90 +14,76 @@
         Check your answers before sending your application
       </h1>
 
-      <p>
-        When a user has entered data on pages, show it by using code like this:
-      </p>
+      <div class="form-group">
 
-      <pre>
-        <div class="code">{% raw %}
-  &lt;tr&gt;
-    &lt;td&gt;
-      Vehicle type:
-    &lt;/td&gt;
-    &lt;td&gt;
-      {{data['vehicle-type']}}
-    &lt;/td&gt;
-  &lt;/tr&gt;
-  {% endraw %}</div></pre>
+        <table class="check-your-answers">
+
+          <thead>
+            <tr>
+              <th colspan="2">
+                <h2 class="heading-medium">
+                  Vehicle details
+                </h2>
+              </th>
+              <th>
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+                Registration number
+              </td>
+              <td>
+                {{data['vehicle-registration']}}
+              </td>
+              <td class="change-answer">
+                <a href="/docs/examples/pass-data/vehicle-registration">
+                  Change <span class="visuallyhidden">registration number</span>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Vehicle type
+              </td>
+              <td>
+                {{data['vehicle-type']}}
+              </td>
+              <td class="change-answer">
+                <a href="/docs/examples/pass-data/vehicle-type">
+                  Change <span class="visuallyhidden">vehicle type</span>
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Vehicle features
+              </td>
+              <td>
+                {{data['vehicle-features']}}
+              </td>
+              <td class="change-answer">
+                <a href="/docs/examples/pass-data/vehicle-features">
+                  Change <span class="visuallyhidden">vehicle features</span>
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="form-group">
+        <p>
+          <a href="/docs/examples">
+            Return to prototype kit examples
+          </a>
+        </p>
+      </div>
+
     </div>
-  </div>
 
-  <div class="form-group">
-
-    <table class="check-your-answers">
-
-      <thead>
-        <tr>
-          <th colspan="2">
-            <h2 class="heading-medium">
-              Vehicle details
-            </h2>
-          </th>
-          <th>
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Registration number
-          </td>
-          <td>
-            {{data['vehicle-registration']}}
-          </td>
-          <td class="change-answer">
-            <a href="/docs/examples/pass-data/">
-              Change <span class="visuallyhidden">registration number</span>
-            </a>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Vehicle type
-          </td>
-          <td>
-            {{data['vehicle-type']}}
-          </td>
-          <td class="change-answer">
-            <a href="/docs/examples/pass-data/vehicle-type">
-              Change <span class="visuallyhidden">vehicle type</span>
-            </a>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            Vehicle features
-          </td>
-          <td>
-            {{data['vehicle-features']}}
-          </td>
-          <td class="change-answer">
-            <a href="/docs/examples/pass-data/vehicle-features">
-              Change <span class="visuallyhidden">vehicle features</span>
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="form-group">
-    <p>
-      <a href="/docs/examples">
-        Return to prototype kit examples
-      </a>
-    </p>
   </div>
 
 </main>

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -25,7 +25,7 @@
       Vehicle type:
     &lt;/td&gt;
     &lt;td&gt;
-      {{vehicleType}}
+      {{data['vehicleType']}}
     &lt;/td&gt;
   &lt;/tr&gt;
   {% endraw %}</div></pre>
@@ -54,7 +54,7 @@
             Registration number
           </td>
           <td>
-            {{vehicleRegistration}}
+            {{data['vehicleRegistration']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/">
@@ -67,7 +67,7 @@
             Vehicle type
           </td>
           <td>
-            {{vehicleType}}
+            {{data['vehicleType']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/vehicle-type">
@@ -80,7 +80,7 @@
             Vehicle features
           </td>
           <td>
-            {{vehicleFeatures}}
+            {{data['vehicleFeatures']}}
           </td>
           <td class="change-answer">
             <a href="/docs/examples/pass-data/vehicle-features">

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -62,7 +62,13 @@ Check your answers
                 Vehicle features
               </td>
               <td>
-                {{data['vehicle-features']}}
+                <ul>
+                  {% for feature in data['vehicle-features'] %}
+                    <li>{{ feature }}</li>
+                  {% else %}
+                    <li>No features selected</li>
+                  {% endfor %}
+                </ul>
               </td>
               <td class="change-answer">
                 <a href="/docs/examples/pass-data/vehicle-features">

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -82,7 +82,7 @@ Check your answers
 
       <div class="form-group">
         <p>
-          <a href="/docs/examples">
+          <a href="/docs/tutorials-and-examples">
             Return to prototype kit examples
           </a>
         </p>

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -1,0 +1,55 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Passing data
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form action="/docs/examples/pass-data/vehicle-check-answers" method="post" class="form">
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">
+              Which of these applies to your vehicle? (Select all that apply)
+            </legend>
+
+            <p class="heading-medium">
+              Which of these applies to your vehicle? (Select all that apply)
+            </p>
+
+            <label class="block-label" for="vehicle-feature-heated-seats">
+              <input id="vehicle-feature-heated-seats" name="vehicleFeatures" type="checkbox" value="Heated seats" {{ checked("vehicleFeatures","Heated seats") }}>
+              Heated seats
+            </label>
+
+            <label class="block-label" for="vehicle-feature-gps">
+              <input id="vehicle-feature-gps" name="vehicleFeatures" type="checkbox" value="GPS" {{ checked("vehicleFeatures","GPS") }}>
+              GPS
+            </label>
+
+            <label class="block-label" for="vehicle-feature-radio">
+              <input id="vehicle-feature-radio" name="vehicleFeatures" type="checkbox" value="Radio" {{ checked("vehicleFeatures","Radio") }}>
+              Radio
+            </label>
+
+          </fieldset>
+        </div>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue">
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -14,22 +14,26 @@
 
       <form action="/docs/examples/pass-data/vehicle-check-answers" method="post" class="form">
 
+        <h1 class="heading-medium">
+          Which of these applies to your vehicle?
+        </h1>
+
         <div class="form-group">
           <fieldset>
 
             <legend class="visuallyhidden">
-              Which of these applies to your vehicle? (Select all that apply)
+              Which of these applies to your vehicle?
             </legend>
 
-            <p class="heading-medium">
-              Which of these applies to your vehicle? (Select all that apply)
+            <p>
+              Select all that apply
             </p>
 
             <div class="multiple-choice">
               <input id="vehicle-feature-heated-seats" name="vehicle-features" type="checkbox" value="Heated seats" {{ checked("vehicle-features", "Heated seats") }}>
               <label for="vehicle-feature-heated-seats">Heated seats</label>
             </div>
-            
+
             <div class="multiple-choice">
               <input id="vehicle-feature-gps" name="vehicle-features" type="checkbox" value="GPS" {{ checked("vehicle-features", "GPS") }}>
               <label for="vehicle-feature-gps">GPS</label>

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -25,20 +25,20 @@
               Which of these applies to your vehicle? (Select all that apply)
             </p>
 
-            <label class="block-label" for="vehicle-feature-heated-seats">
-              <input id="vehicle-feature-heated-seats" name="vehicleFeatures" type="checkbox" value="Heated seats" {{ checked("vehicleFeatures","Heated seats") }}>
-              Heated seats
-            </label>
+            <div class="multiple-choice">
+              <input id="vehicle-feature-heated-seats" name="vehicle-features" type="checkbox" value="Heated seats" {{ checked("vehicle-features", "Heated seats") }}>
+              <label for="vehicle-feature-heated-seats">Heated seats</label>
+            </div>
+            
+            <div class="multiple-choice">
+              <input id="vehicle-feature-gps" name="vehicle-features" type="checkbox" value="GPS" {{ checked("vehicle-features", "GPS") }}>
+              <label for="vehicle-feature-gps">GPS</label>
+            </div>
 
-            <label class="block-label" for="vehicle-feature-gps">
-              <input id="vehicle-feature-gps" name="vehicleFeatures" type="checkbox" value="GPS" {{ checked("vehicleFeatures","GPS") }}>
-              GPS
-            </label>
-
-            <label class="block-label" for="vehicle-feature-radio">
-              <input id="vehicle-feature-radio" name="vehicleFeatures" type="checkbox" value="Radio" {{ checked("vehicleFeatures","Radio") }}>
-              Radio
-            </label>
+            <div class="multiple-choice">
+              <input id="vehicle-feature-radio" name="vehicle-features" type="checkbox" value="Radio" {{ checked("vehicle-features", "Radio") }}>
+              <label for="vehicle-feature-radio">Radio</label>
+            </div>
 
           </fieldset>
         </div>

--- a/docs/views/examples/pass-data/vehicle-registration.html
+++ b/docs/views/examples/pass-data/vehicle-registration.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Passing data
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form action="/docs/examples/pass-data/vehicle-type" method="post" class="form">
+
+        <h1 class="heading-medium">
+          What is your vehicle registration number?
+        </h1>
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">
+              What is your vehicle registration number?
+            </legend>
+
+            <label class="visually-hidden" for="registration-number">Vehicle registration number</label>
+            <input class="form-control" id="registration-number" name="vehicle-registration" type="text" value="{{data['vehicle-registration']}}">
+
+          </fieldset>
+        </div>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue">
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/docs/views/examples/pass-data/vehicle-type.html
+++ b/docs/views/examples/pass-data/vehicle-type.html
@@ -1,0 +1,55 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Passing data
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form action="/docs/examples/pass-data/vehicle-features" method="post" class="form">
+
+        <div class="form-group">
+          <fieldset>
+
+            <legend class="visuallyhidden">
+              What type of vehicle do you have?
+            </legend>
+
+            <p class="heading-medium">
+              What type of vehicle do you have?
+            </p>
+
+            <label class="block-label" for="vehicle-type-car">
+              <input id="vehicle-type-car" type="radio" name="vehicleType" value="Car" {{ checked("vehicleType","Car") }}>
+              Car
+            </label>
+
+            <label class="block-label" for="vehicle-type-lorry">
+              <input id="vehicle-type-lorry" type="radio" name="vehicleType" value="Lorry" {{ checked("vehicleType","Lorry") }}>
+              Lorry
+            </label>
+
+            <label class="block-label" for="vehicle-type-motorcycle">
+              <input id="vehicle-type-motorcycle" type="radio" name="vehicleType" value="Motorcycle" {{ checked("vehicleType","Motorcycle") }}>
+              Motorcycle
+            </label>
+
+          </fieldset>
+        </div>
+
+        <div class="form-group">
+          <input type="submit" class="button" value="Continue">
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/docs/views/examples/pass-data/vehicle-type.html
+++ b/docs/views/examples/pass-data/vehicle-type.html
@@ -25,20 +25,20 @@
               What type of vehicle do you have?
             </p>
 
-            <label class="block-label" for="vehicle-type-car">
-              <input id="vehicle-type-car" type="radio" name="vehicleType" value="Car" {{ checked("vehicleType","Car") }}>
-              Car
-            </label>
+            <div class="multiple-choice">
+              <input id="vehicle-type-car" name="vehicle-type" type="radio" value="Car" {{ checked("vehicle-type", "Car") }}>
+              <label for="vehicle-type-car">Car</label>
+            </div>
 
-            <label class="block-label" for="vehicle-type-lorry">
-              <input id="vehicle-type-lorry" type="radio" name="vehicleType" value="Lorry" {{ checked("vehicleType","Lorry") }}>
-              Lorry
-            </label>
+            <div class="multiple-choice">
+              <input id="vehicle-type-lorry" name="vehicle-type" type="radio" value="Lorry" {{ checked("vehicle-type", "Lorry") }}>
+              <label for="vehicle-type-lorry">Lorry</label>
+            </div>
 
-            <label class="block-label" for="vehicle-type-motorcycle">
-              <input id="vehicle-type-motorcycle" type="radio" name="vehicleType" value="Motorcycle" {{ checked("vehicleType","Motorcycle") }}>
-              Motorcycle
-            </label>
+            <div class="multiple-choice">
+              <input id="vehicle-type-motorcycle" name="vehicle-type" type="radio" value="Motorcycle" {{ checked("vehicle-type", "Motorcycle") }}>
+              <label for="vehicle-type-motorcycle">Motorcycle</label>
+            </div>
 
           </fieldset>
         </div>

--- a/docs/views/examples/pass-data/vehicle-type.html
+++ b/docs/views/examples/pass-data/vehicle-type.html
@@ -14,16 +14,16 @@
 
       <form action="/docs/examples/pass-data/vehicle-features" method="post" class="form">
 
+        <h1 class="heading-medium">
+          What type of vehicle do you have?
+        </h1>
+
         <div class="form-group">
           <fieldset>
 
             <legend class="visuallyhidden">
               What type of vehicle do you have?
             </legend>
-
-            <p class="heading-medium">
-              What type of vehicle do you have?
-            </p>
 
             <div class="multiple-choice">
               <input id="vehicle-type-car" name="vehicle-type" type="radio" value="Car" {{ checked("vehicle-type", "Car") }}>

--- a/docs/views/includes/scripts.html
+++ b/docs/views/includes/scripts.html
@@ -4,3 +4,7 @@
 <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
 <script src="/public/javascripts/govuk/show-hide-content.js"></script>
 <script src="/public/javascripts/docs.js"></script>
+
+{% if useAutoStoreData %}
+  <script src="/public/javascripts/auto-store-data.js"></script>
+{% endif %}

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -37,6 +37,16 @@
   with-proposition
 {% endblock %}
 
+{% block footer_support_links %}
+  {% if useAutoStoreData %}
+    <ul>
+      <li>
+        <a href="/prototype-admin/clear-data">Clear data</a>
+      </li>
+    </ul>
+  {% endif %}
+{% endblock %}
+
 {% block body_end %}
   {% include "includes/scripts.html" %}
   <!-- GOV.UK Prototype kit {{releaseVersion}} -->

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -55,6 +55,9 @@
     <div class="column-third">
       <h3 class="heading-small">Advanced usage</h3>
       <ul class="list list-bullet">
+        <li>
+          <a href="/docs/examples/pass-data">Passing data from page to page</a>
+        </li>
         <li><a href="/docs/examples/branching">Branching</a>
           <p class="font-xsmall">(Showing a different page based on user input)</p>
         </li>

--- a/lib/prototype-admin/clear-data.html
+++ b/lib/prototype-admin/clear-data.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Clear data
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  
+  <h1 class="heading-medium">
+    Data cleared
+  </h1>
+
+  <p>
+    The session data has been cleared.
+  </p>
+
+  <p>
+    <a href="/">
+      Prototype home page
+    </a>
+  </p>
+  
+</main>
+
+{% endblock %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -214,8 +214,10 @@ exports.autoStoreData = function (req, res, next) {
 
   // send session data to all views
 
+  res.locals.data = {}
+
   for (var j in req.session.data) {
-    res.locals[j] = req.session.data[j]
+    res.locals.data[j] = req.session.data[j]
   }
 
   next()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -180,24 +180,20 @@ exports.matchMdRoutes = function (req, res) {
   return false
 }
 
-// Middleware - store any data sent in session, and pass it to all views
+// store data from POST body or GET query in session
 
-exports.autoStoreData = function (req, res, next) {
-  if (!req.session.data) {
-    req.session.data = {}
-  }
-
-  for (var i in req.body) {
+var storeData = function (input, store) {
+  for (var i in input) {
     // any input where the name starts with _ is ignored
     if (i.indexOf('_') === 0) {
       continue
     }
 
-    var val = req.body[i]
+    var val = input[i]
 
     // delete single unchecked checkboxes
     if (val === '_unchecked' || val === ['_unchecked']) {
-      delete req.session.data[i]
+      delete store.data[i]
       continue
     }
 
@@ -209,8 +205,19 @@ exports.autoStoreData = function (req, res, next) {
       }
     }
 
-    req.session.data[i] = val
+    store.data[i] = val
   }
+}
+
+// Middleware - store any data sent in session, and pass it to all views
+
+exports.autoStoreData = function (req, res, next) {
+  if (!req.session.data) {
+    req.session.data = {}
+  }
+
+  storeData(req.body, req.session)
+  storeData(req.query, req.session)
 
   // send session data to all views
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -179,3 +179,44 @@ exports.matchMdRoutes = function (req, res) {
   }
   return false
 }
+
+// Middleware - store any data sent in session, and pass it to all views
+
+exports.autoStoreData = function (req, res, next) {
+  if (!req.session.data) {
+    req.session.data = {}
+  }
+
+  for (var i in req.body) {
+    // any input where the name starts with _ is ignored
+    if (i.indexOf('_') === 0) {
+      continue
+    }
+
+    var val = req.body[i]
+
+    // delete single unchecked checkboxes
+    if (val === '_unchecked' || val === ['_unchecked']) {
+      delete req.session.data[i]
+      continue
+    }
+
+    // remove _unchecked from arrays
+    if (Array.isArray(val)) {
+      var index = val.indexOf('_unchecked')
+      if (index !== -1) {
+        val.splice(index, 1)
+      }
+    }
+
+    req.session.data[i] = val
+  }
+
+  // send session data to all views
+
+  for (var j in req.session.data) {
+    res.locals[j] = req.session.data[j]
+  }
+
+  next()
+}

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ var username = process.env.USERNAME
 var password = process.env.PASSWORD
 var env = process.env.NODE_ENV || 'development'
 var useAuth = process.env.USE_AUTH || config.useAuth
+var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
 var useHttps = process.env.USE_HTTPS || config.useHttps
 var analyticsId = process.env.ANALYTICS_TRACKING_ID
 
@@ -106,10 +107,87 @@ app.use(session({
 // Add variables that are available in all views
 app.locals.analyticsId = analyticsId
 app.locals.asset_path = '/public/'
+app.locals.useAutoStoreData = (useAutoStoreData === 'true')
 app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
+
+// Force HTTPs on production connections
+if (env === 'production' && useHttps === 'true') {
+  app.use(utils.forceHttps)
+}
+
+if (useAutoStoreData === 'true') {
+  app.use(utils.autoStoreData)
+  app.use(function (req, res, next) {
+    // add nunjucks function to get values, needs to be here as they need access to req.session
+
+    nunjucksAppEnv.addGlobal('checked', function (name, value) {
+      if (req.session.data === undefined) {
+        return ''
+      }
+
+      var storedValue = req.session.data[name]
+
+      if (storedValue === undefined) {
+        return ''
+      }
+
+      if (Array.isArray(storedValue)) {
+        var inArray = storedValue.indexOf(value) !== -1
+        return inArray ? 'checked' : ''
+      } else {
+        return value === storedValue ? 'checked' : ''
+      }
+    })
+
+    next()
+  })
+
+  documentationApp.use(utils.autoStoreData)
+  documentationApp.use(function (req, res, next) {
+    // add nunjucks function to get values, needs to be here as they need access to req.session
+
+    nunjucksDocumentationEnv.addGlobal('checked', function (name, value) {
+      if (req.session.data === undefined) {
+        return ''
+      }
+
+      var storedValue = req.session.data[name]
+
+      if (storedValue === undefined) {
+        return ''
+      }
+
+      if (Array.isArray(storedValue)) {
+        var inArray = storedValue.indexOf(value) !== -1
+        return inArray ? 'checked' : ''
+      } else {
+        return value === storedValue ? 'checked' : ''
+      }
+    })
+
+    next()
+  })
+}
+
+// Disallow search index idexing
+app.use(function (req, res, next) {
+  // Setting headers stops pages being indexed even if indexed pages link to them.
+  res.setHeader('X-Robots-Tag', 'noindex')
+  next()
+})
+
+app.get('/robots.txt', function (req, res) {
+  res.type('text/plain')
+  res.send('User-agent: *\nDisallow: /')
+})
+
+app.get('/prototype-admin/clear-data', function (req, res) {
+  req.session.destroy()
+  res.render('prototype-admin/clear-data')
+})
 
 // Redirect root to /docs when in promo mode.
 if (promoMode === 'true') {
@@ -188,6 +266,11 @@ if (useDocumentation) {
     }
   })
 }
+
+// redirect all POSTs to GETs - this allows users to use POST for autoStoreData
+app.post(/^\/([^.]+)$/, function (req, res) {
+  res.redirect('/' + req.params[0])
+})
 
 console.log('\nGOV.UK Prototype kit v' + releaseVersion)
 // Display warning not to use kit for production services.

--- a/server.js
+++ b/server.js
@@ -40,8 +40,12 @@ if (!useDocumentation) promoMode = 'false'
 // Force HTTPs on production connections. Do this before asking for basicAuth to
 // avoid making users fill in the username/password twice (once for `http`, and
 // once for `https`).
-if (env === 'production' && useHttps === 'true') {
+
+var isSecure = (env === 'production' && useHttps === 'true')
+
+if (isSecure) {
   app.use(utils.forceHttps)
+  app.set('trust proxy', 1) // needed for secure cookies on heroku
 }
 
 // Authenticate against the environment-provided credentials, if running
@@ -106,15 +110,6 @@ app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
-
-var isSecure = false
-
-// Force HTTPs on production connections
-if (env === 'production' && useHttps === 'true') {
-  app.use(utils.forceHttps)
-  app.set('trust proxy', 1) // needed for secure cookies on heroku
-  isSecure = true
-}
 
 // Support session data
 app.use(session({

--- a/server.js
+++ b/server.js
@@ -145,7 +145,6 @@ if (useAutoStoreData === 'true') {
     next()
   })
 
-  documentationApp.use(utils.autoStoreData)
   documentationApp.use(function (req, res, next) {
     // add nunjucks function to get values, needs to be here as they need access to req.session
 


### PR DESCRIPTION
this updates #214 Auto data session 3 so it can be merged - copied from that PR:

This version of automatically storing and showing data across pages does not rely on macros, but instead using the `checked` function directly (see examples below). I'm not sure it's as user-friendly as the version with macros, but it may take a while to finalise our approach to macros.
# Usage

This will make the kit automatically store all data from forms, for use later in your prototype.

For example if you have an input like this:

```
<input name="first-name">
```

You can put this on the next page, or any other page:

```
<p>Hello {{data['first-name']}}</p>
```
## Population

To populate a text field with the value a user entered is simple:

```
<input name="first-name" value="{{data['first-name']}}">
```

To set radios or checkboxes use this:

```
{{ checked(name, value) }}
```

Using the name and value of the input. For example:

```
<input type="radio" name="over-18" value="Yes" {{checked("over-18", "Yes")}}>

<input type="checkbox" name="send-spam" value="No" {{checked("send-spam", "No")}}>

```

## Dealing with checkboxes

This adds javascript so that when a user submits a form, the script looks for checkboxes in that form. For any checkbox, or group of checkboxes with the same name attribute, it adds a hidden input of the same name, with value "_unchecked". If the server only receives "_unchecked", it clears any data associated with that name.