### PR TITLE
Remove the title attribute from the cookie message

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -19,6 +19,6 @@ module.exports = {
   useHttps: 'true',
 
   // Cookie warning - update link to service's cookie page.
-  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#" title="Find out more about cookies">Find out more about cookies</a>'
+  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>'
 
 }


### PR DESCRIPTION
To match the change made to GOV.UK elements: https://github.com/alphagov/govuk_elements/pull/389 by @robinwhittleton. 