### PR TITLE
Add IE 8 bind polyfill

### DIFF
--- a/app/assets/javascripts/bind.js
+++ b/app/assets/javascripts/bind.js
@@ -1,0 +1,42 @@
+/* eslint-disable */
+
+// Function.prototype.bind
+//
+// A polyfill for Function.prototype.bind. Which lets you bind a defined
+// value to the `this` keyword in a function call.
+//
+// Bind is natively supported in:
+//   IE9+
+//   Chrome 7+
+//   Firefox 4+
+//   Safari 5.1.4+
+//   iOS 6+
+//   Android Browser 4+
+//   Chrome for Android 0.16+
+//
+// Originally from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,4 +1,5 @@
 <!-- Javascript -->
+<!--[if lte IE 8]><script src="/public/javascripts/bind.js"></script><![endif]-->
 <script src="/public/javascripts/details.polyfill.js"></script>
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>

--- a/docs/views/includes/scripts.html
+++ b/docs/views/includes/scripts.html
@@ -1,4 +1,5 @@
 <!-- Javascript -->
+<!--[if lte IE 8]><script src="/public/javascripts/bind.js"></script><![endif]-->
 <script src="/public/javascripts/details.polyfill.js"></script>
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>


### PR DESCRIPTION
bind.js taken from govuk frontend toolkit. Condition added to use this file if the browser is IE 8 or less.

Fixes #348.