### PR TITLE
Prevent asking users to authenticate twice

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,13 @@ promoMode = promoMode.toLowerCase()
 // Disable promo mode if docs aren't enabled
 if (!useDocumentation) promoMode = 'false'
 
+// Force HTTPs on production connections. Do this before asking for basicAuth to
+// avoid making users fill in the username/password twice (once for `http`, and
+// once for `https`).
+if (env === 'production' && useHttps === 'true') {
+  app.use(utils.forceHttps)
+}
+
 // Authenticate against the environment-provided credentials, if running
 // the app in production (Heroku, effectively)
 if (env === 'production' && useAuth === 'true') {
@@ -103,11 +110,6 @@ app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
-
-// Force HTTPs on production connections
-if (env === 'production' && useHttps === 'true') {
-  app.use(utils.forceHttps)
-}
 
 // Disallow search index idexing
 app.use(function (req, res, next) {


### PR DESCRIPTION
This solves the problem with prototypes asking for username/password twice.

The problem is caused by the ordering in the middleware. When a user types in the URL for a prototype like http://govuk-tagging.herokuapp.com they're asked for a username/password first (via `utils.basicAuth`).

After filling that in they'll be able to "proceed" to the next step, which redirects them to the `https://` version (via `utils.forceHttps`). Because the auth isn't shared between `http` and `https` version, they are not authenticated anymore and have to enter their username/password again.

Validated with http://test-prevent-double-auth.herokuapp.com/

## Before

```
 @tijmenb ~/govuk/govuk_prototype_kit on prevent-double-auth $ curl -I http://govuk-tagging.herokuapp.com/
HTTP/1.1 401 Unauthorized
```

## After

```
 @tijmenb ~/govuk/govuk_prototype_kit on prevent-double-auth $ curl -I http://test-prevent-double-auth.herokuapp.com/
HTTP/1.1 302 Found
Location: https://test-prevent-double-auth.herokuapp.com/
```