### PR TITLE
bump gulp-sass to increase node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-clean": "^0.3.2",
     "gulp-mocha": "^3.0.1",
     "gulp-nodemon": "^2.1.0",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "3.0.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "marked": "^0.3.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-clean": "^0.3.2",
     "gulp-mocha": "^3.0.1",
     "gulp-nodemon": "^2.1.0",
-    "gulp-sass": "3.0.0",
+    "gulp-sass": "3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "marked": "^0.3.6",


### PR DESCRIPTION
# Npm install AWS Elastic Beanstalk fails

Currently when deploying the Gov UK prototype kit to AWS using their Linux node AMI with nodeJs `6.9.1` the [node-sass](https://github.com/dlmanning/gulp-sass/blob/218560fc06f6e94151fb5ec3a4e0e047415c14ed/package.json#L26) dependency of `gulp-sass` `v2.3.2` is incompatible with nodeJs 6 and Linux [node-sass/releases/tag/v3.4.2](https://github.com/sass/node-sass/releases/tag/v3.4.2)

To enable this to work we need to bump `gulp-sass` to `v3.0.0` that has [node-sass](https://github.com/dlmanning/gulp-sass/blob/0d2a2bffb679667b302259bce4d389c9d3dcd975/package.json#L26) `v4.0.0` which [is supported](https://github.com/sass/node-sass/releases/tag/v4.0.0) on Linux with nodeJs 6