### PR TITLE
Add test for docs page

### DIFF
--- a/test/spec/sanity-checks.js
+++ b/test/spec/sanity-checks.js
@@ -30,4 +30,18 @@ describe('The prototype kit', function () {
         }
       })
   })
+
+  it('should send with a well formed response for the docs page', function (done) {
+    request(app)
+      .get('/docs')
+      .expect('Content-Type', /text\/html/)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) {
+          done(err)
+        } else {
+          done()
+        }
+      })
+  })
 })


### PR DESCRIPTION
It's worth testing for /docs as it's served by a different app, with its own template structure.

This would have caught the recent bug that broke the prototype kit site (99b145d61af)