### PR TITLE
fix docs links

### DIFF
--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -4,9 +4,9 @@ This guide will walk you through installing and getting started with the kit. Yo
 
 Installation takes up to 30 minutes depending on how much you need to install.
 
-If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](../developer-install-instructions.md).
+If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](developer-install-instructions).
 
-> This guide is a work in progress. Please help [contribute](../../CONTRIBUTING.md) to make it even better.
+> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk_prototype_kit/blob/master/CONTRIBUTING.md) to make it even better.
 
 ## Introduction
 


### PR DESCRIPTION
this fixes #339, and another broken link on that page to the developer install instructions