### PR TITLE
Bump govuk_frontend_toolkit to 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "2.2.1",
-    "govuk_frontend_toolkit": "5.0.2",
+    "govuk_frontend_toolkit": "5.1.1",
     "govuk_template_jinja": "0.19.2",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
Update the govuk_frontend_toolkit to include the following changes:

# 5.1.1

- Update the alpha, beta and discovery colours to $govuk-blue to match
the updated phase banner ([PR #370](https://github.com/alphagov/govuk_frontend_toolkit/pull/370))
- Fix radio button show/hide behaviour when used outside a form ([PR #375](https://github.com/alphagov/govuk_frontend_toolkit/pull/375))
- Fix a "Stick at top when scrolling" component bug related to scroll
anchoring in Chrome 56+ ([PR #376](https://github.com/alphagov/govuk_frontend_toolkit/pull/376))
- Minor travis fixes ([PR #373](https://github.com/alphagov/govuk_frontend_toolkit/pull/373))

# 5.1.0

- Allow custom options when tracking events ([PR #365](https://github.com/alphagov/govuk_frontend_toolkit/pull/365))

# 5.0.3

- Change HMRC and DEFRA text colours for improved contrast ([PR #368](https://github.com/alphagov/govuk_frontend_toolkit/pull/368))