### PR TITLE
Improvements to Check your answers page

### DIFF
--- a/app/assets/sass/patterns/_check-your-answers.scss
+++ b/app/assets/sass/patterns/_check-your-answers.scss
@@ -1,14 +1,82 @@
-.check-your-answers {
 
-  td {
-    @include core-19;
-    vertical-align: top;
+.govuk-check-your-answers {
+
+  @include media(desktop) {
+    display: table;
   }
 
-  .change-answer {
-    text-align: right;
+  > * {
+    position: relative;
+    border-bottom: 1px solid $border-colour;
+
+    @include media(desktop) {
+      display: table-row;
+      border-bottom-width: 0;
+    }
+
+    > * {
+      display: block;
+
+      @include media(desktop) {
+        display: table-cell;
+        border-bottom: 1px solid $border-colour;
+        padding: em(12, 19) em(20, 19) em(9, 19) 0; // copied from Elements' td padding
+        margin: 0;
+      }
+    }
+
+    @include media(desktop) {
+      &:first-child > * {
+        padding-top: 0;
+      }
+    }
+  }
+
+  .cya-question {
     font-weight: bold;
-    padding-right: 0;
+    margin: em(12, 19) 4em em(4,19) 0;
+    // top: from Elements' td
+    // right: due to length of "change" link (adjust if you change the link to be much longer)
+    // bottom: by eye
+    // using margin instead of padding because of easier absolutely positioning of .change
+  }
+
+  > *:first-child .cya-question {
+    margin-top: 0;
+  }
+
+  @include media(desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    &.cya-questions-short,
+    &.cya-questions-long {
+      width: 100%;
+    }
+
+    // recommended for mostly short questions
+    &.cya-questions-short .cya-question {
+      width: 30%;
+    }
+
+    // recommended for mostly long questions
+    &.cya-questions-long .cya-question {
+      width: 50%;
+    }
+  }
+
+  .cya-answer {
+    padding-bottom: em(9, 19); // from Elements' td
+  }
+
+  .cya-change {
+    text-align: right;
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    @include media(desktop) {
+      position: static;
+      padding-right: 0;
+    }
   }
 
 }

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -34,7 +34,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">name</span>
+              Change<span class="visually-hidden"> name</span>
             </a>
           </dd>
         </div>
@@ -48,7 +48,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">date of birth</span>
+              Change<span class="visually-hidden"> date of birth</span>
             </a>
           </dd>
         </div>
@@ -64,7 +64,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">home address</span>
+              Change<span class="visually-hidden"> home address</span>
             </a>
           </dd>
         </div>
@@ -79,7 +79,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">contact details</span>
+              Change<span class="visually-hidden"> contact details</span>
             </a>
           </dd>
         </div>
@@ -100,7 +100,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">previous application number</span>
+              Change<span class="visually-hidden"> previous application number</span>
             </a>
           </dd>
         </div>
@@ -114,7 +114,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">licence type</span>
+              Change<span class="visually-hidden"> licence type</span>
             </a>
           </dd>
         </div>
@@ -130,7 +130,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">home address</span>
+              Change<span class="visually-hidden"> home address</span>
             </a>
           </dd>
         </div>
@@ -145,7 +145,7 @@
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">licence period</span>
+              Change<span class="visually-hidden"> licence period</span>
             </a>
           </dd>
         </div>

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -14,105 +14,143 @@
         Check your answers before sending your application
       </h1>
 
+
+      <!-- only add a heading for a list if there is more than one list -->
       <h2 class="heading-medium">
-        Organisations involved
+        Personal details
       </h2>
 
-      <dl class="govuk-check-your-answers">
+      <!-- use additional modifier class to change column widths for multiple groups of questions and answers: -->
+      <!--   * `cya-questions-short` for short questions -->
+      <!--   * `cya-questions-long` for long questions -->
+      <!--   * none for single group of q&a -->
+      <dl class="govuk-check-your-answers cya-questions-short">
         <div>
           <dt class="cya-question">
-            Exporter
+            Name
           </dt>
           <dd class="cya-answer">
-            Exporter name<br>
-            First line of address<br>
-            Second line of address<br>
-            Contact: Contact Name<br>
-            Tel: 01234 567 890<br>
-            Email: email@email.com
+            Sarah Philips
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">Exporter name</span>
+              Change <span class="visuallyhidden">name</span>
             </a>
           </dd>
         </div>
 
         <div>
           <dt class="cya-question">
-            Producer
+            Date of birth
           </dt>
           <dd class="cya-answer">
-            Producer name
+            5 January 1978
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">Producer name</span>
+              Change <span class="visuallyhidden">date of birth</span>
             </a>
           </dd>
         </div>
 
         <div>
           <dt class="cya-question">
-            Site of export
+            Home address
           </dt>
           <dd class="cya-answer">
-            Site of export name
+            72 Guild Street<br />
+            London<br />
+            SE23 6FH
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">Site of export name</span>
+              Change <span class="visuallyhidden">home address</span>
             </a>
           </dd>
         </div>
 
         <div>
           <dt class="cya-question">
-            Importer
+            Contact details
           </dt>
           <dd class="cya-answer">
-            Importer name<br>
-            First line of address<br>
-            Second line of address<br>
-            Contact: Contact Name<br>
-            Tel: 01234 567 890<br>
-            Email: email@email.com
+            07700 900457<br />
+            sarah.phillips@example.com
           </dd>
           <dd class="cya-change">
             <a href="#">
-              Change <span class="visuallyhidden">Importer name</span>
-            </a>
-          </dd>
-        </div>
-
-        <div>
-          <dt class="cya-question">
-            Recovery facilities
-          </dt>
-          <dd class="cya-answer">
-            Recovery facilities name
-          </dd>
-          <dd class="cya-change">
-            <a href="#">
-              Change <span class="visuallyhidden">Recovery facilities name</span>
-            </a>
-          </dd>
-        </div>
-
-        <div>
-          <dt class="cya-question">
-            Recovery site
-          </dt>
-          <dd class="cya-answer">
-            Recovery site name
-          </td>
-          <dd class="cya-change">
-            <a href="#">
-              Change <span class="visuallyhidden">Recovery site name</span>
+              Change <span class="visuallyhidden">contact details</span>
             </a>
           </dd>
         </div>
       </dl>
+
+
+      <h2 class="heading-medium">
+        Application details
+      </h2>
+
+      <dl class="govuk-check-your-answers cya-questions-short">
+        <div>
+          <dt class="cya-question">
+            Previous application number
+          </dt>
+          <dd class="cya-answer">
+            502135326
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">previous application number</span>
+            </a>
+          </dd>
+        </div>
+
+        <div>
+          <dt class="cya-question">
+            Licence type
+          </dt>
+          <dd class="cya-answer">
+            For personal use
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">licence type</span>
+            </a>
+          </dd>
+        </div>
+
+        <div>
+          <dt class="cya-question">
+            Home address
+          </dt>
+          <dd class="cya-answer">
+            72 Guild Street<br />
+            London<br />
+            SE23 6FH
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">home address</span>
+            </a>
+          </dd>
+        </div>
+
+        <div>
+          <dt class="cya-question">
+            Licence period
+          </dt>
+          <dd class="cya-answer">
+            This is a longer paragraph of text provided by the user to provide additional information.<br /><br />
+            This is a second paragraph of text provided by the user.
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">licence period</span>
+            </a>
+          </dd>
+        </div>
+      </dl>
+
 
       <h2 class="heading-medium">Now send your application</h2>
 

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -7,127 +7,125 @@
 {% block content %}
 
 <main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
 
-  <h1 class="heading-large">
-    Check your answers before sending your application
-  </h1>
+      <h1 class="heading-large">
+        Check your answers before sending your application
+      </h1>
 
-  <table class="check-your-answers">
+      <h2 class="heading-medium">
+        Organisations involved
+      </h2>
 
-    <thead>
-      <tr>
-        <th colspan="2">
-          <h2 class="heading-medium">
-            Organisations involved
-          </h2>
-        </th>
-        <th>
-        </th>
-      </tr>
-    </thead>
+      <dl class="govuk-check-your-answers">
+        <div>
+          <dt class="cya-question">
+            Exporter
+          </dt>
+          <dd class="cya-answer">
+            Exporter name<br>
+            First line of address<br>
+            Second line of address<br>
+            Contact: Contact Name<br>
+            Tel: 01234 567 890<br>
+            Email: email@email.com
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Exporter name</span>
+            </a>
+          </dd>
+        </div>
 
-    <tbody>
-      <tr>
-        <td>
-          Exporter
-        </td>
-        <td>
-          Exporter name<br>
-          First line of address<br>
-          Second line of address<br>
-          Contact: Contact Name<br>
-          Tel: 01234 567 890<br>
-          Email: email@email.com
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Exporter name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Producer
-        </td>
-        <td>
-          Producer name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Producer name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Site of export
-        </td>
-        <td>
-          Site of export name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Site of export name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Importer
-        </td>
-        <td>
-          Importer name<br>
-          First line of address<br>
-          Second line of address<br>
-          Contact: Contact Name<br>
-          Tel: 01234 567 890<br>
-          Email: email@email.com
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Importer name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Recovery facilities
-        </td>
-        <td>
-          Recovery facilities name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Recovery facilities name</span>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Recovery site
-        </td>
-        <td>
-          Recovery site name
-        </td>
-        <td class="change-answer">
-          <a href="#">
-            Change <span class="visuallyhidden">Recovery site name</span>
-          </a>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+        <div>
+          <dt class="cya-question">
+            Producer
+          </dt>
+          <dd class="cya-answer">
+            Producer name
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Producer name</span>
+            </a>
+          </dd>
+        </div>
 
-  <h2 class="heading-medium">Now send your application</h2>
+        <div>
+          <dt class="cya-question">
+            Site of export
+          </dt>
+          <dd class="cya-answer">
+            Site of export name
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Site of export name</span>
+            </a>
+          </dd>
+        </div>
 
-  <p class="text">
-    By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
-  </p>
+        <div>
+          <dt class="cya-question">
+            Importer
+          </dt>
+          <dd class="cya-answer">
+            Importer name<br>
+            First line of address<br>
+            Second line of address<br>
+            Contact: Contact Name<br>
+            Tel: 01234 567 890<br>
+            Email: email@email.com
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Importer name</span>
+            </a>
+          </dd>
+        </div>
 
-  <div class="form-group">
-    <a href="confirmation-page" class="button">Accept and send application</a>
+        <div>
+          <dt class="cya-question">
+            Recovery facilities
+          </dt>
+          <dd class="cya-answer">
+            Recovery facilities name
+          </dd>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Recovery facilities name</span>
+            </a>
+          </dd>
+        </div>
+
+        <div>
+          <dt class="cya-question">
+            Recovery site
+          </dt>
+          <dd class="cya-answer">
+            Recovery site name
+          </td>
+          <dd class="cya-change">
+            <a href="#">
+              Change <span class="visuallyhidden">Recovery site name</span>
+            </a>
+          </dd>
+        </div>
+      </dl>
+
+      <h2 class="heading-medium">Now send your application</h2>
+
+      <p class="text">
+        By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
+      </p>
+
+      <div class="form-group">
+        <a href="confirmation-page" class="button">Accept and send application</a>
+      </div>
+
+    </div>
   </div>
-
 </main>
 
 {% endblock %}


### PR DESCRIPTION
This makes markup, styling and content improvements to the 'Check your answers' page.

## Markup changes

The markup was changed from a table to a description list.
We initially tried multiple variants which all looked and behaved the same and tested all of them in various assistive technology for potential accessibility issues:
* table (but not the one that is currently in the prototype kit)
* description list (`dl`)
* list (`ul` or `ol`)

We found that they all work nearly equally well and all have pros and cons. The main reason for deciding to use a description list was that it seems to be the most semantic in this case (although the others are not unsemantic). Although description lists have varying support in screen readers, the context made it still easy enough to understand and navigate.

Please note, the description list uses a div around each dt/dd grouping. That is currently invalid but it's in the [HTML 5.2 Working Draft](https://www.w3.org/TR/html52/grouping-content.html#the-dl-element) and it's supported in all the browsers (even IE6).

## Visual changes

* Don't use the full page width if the items are short
* Remove the bold from the change link
* Make the key bold
* Make key and value wrap on smaller screens
* The widths automatically adjust to their content

## Content changes

* Make the text more generic
* Include second section
