### PR TITLE
Added config to turn off browser sync

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -19,6 +19,9 @@ module.exports = {
   useHttps: 'true',
 
   // Cookie warning - update link to service's cookie page.
-  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>'
+  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>',
+
+  // Enable or disable Browser Sync
+  useBrowserSync: 'true'
 
 }

--- a/server.js
+++ b/server.js
@@ -196,7 +196,7 @@ console.log('\nNOTICE: the kit is for building prototypes, do not use it for pro
 // start the app
 utils.findAvailablePort(app, function (port) {
   console.log('Listening on port ' + port + '   url: http://localhost:' + port)
-  if (env === 'production') {
+  if (env === 'production' || config.useBrowserSync === 'false') {
     app.listen(port)
   } else {
     app.listen(port - 50, function () {

--- a/server.js
+++ b/server.js
@@ -20,11 +20,13 @@ var password = process.env.PASSWORD
 var env = process.env.NODE_ENV || 'development'
 var useAuth = process.env.USE_AUTH || config.useAuth
 var useHttps = process.env.USE_HTTPS || config.useHttps
+var useBrowserSync = config.useBrowserSync
 var analyticsId = process.env.ANALYTICS_TRACKING_ID
 
 env = env.toLowerCase()
 useAuth = useAuth.toLowerCase()
 useHttps = useHttps.toLowerCase()
+useBrowserSync = useBrowserSync.toLowerCase()
 
 var useDocumentation = (config.useDocumentation === 'true')
 
@@ -196,7 +198,7 @@ console.log('\nNOTICE: the kit is for building prototypes, do not use it for pro
 // start the app
 utils.findAvailablePort(app, function (port) {
   console.log('Listening on port ' + port + '   url: http://localhost:' + port)
-  if (env === 'production' || config.useBrowserSync === 'false') {
+  if (env === 'production' || useBrowserSync === 'false') {
     app.listen(port)
   } else {
     app.listen(port - 50, function () {


### PR DESCRIPTION
Every time I make a new prototype I have to keep deleting out the browser sync code. I've added an option to the config file to make disabling it much easier in future. It's left enabled by default so there is no change to the way the kit works out the box.