### PR TITLE
Add template pages for content and questions

### DIFF
--- a/docs/views/examples/template-content-page.html
+++ b/docs/views/examples/template-content-page.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Question page
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <a class="link-back" href="/url/of/previous/page">Back</a>
+
+      <h1 class="heading-large">
+        Heading goes here
+      </h1>
+
+      <p>This is a paragraph of text. It explains in more detail what has happened and wraps across several lines.</p>
+
+      <p>This paragraph has a link to <a href="/url/of/onward/page">find out more about this subject</a>.</p>
+
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -1,0 +1,34 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Question page
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <a class="link-back" href="/url/of/previous/page">Back</a>
+
+      <h1 class="heading-large">Heading or question goes here
+      </h1>
+
+      <form class="form" action="/url/of/next/page" method="post">
+
+        <p>[Insert question content here]</p>
+
+        <p>[See <a href="https://govuk-elements.herokuapp.com/form-elements/">GOV.UK Elements</a> for examples]</p>
+
+        <div class="form-group">
+          <input class="button" type="submit" value="Continue">
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -132,17 +132,17 @@
         </li>
         <li>
           <a href="/docs/examples/start-page">
-            Start
+            Start page
+          </a>
+        </li>
+        <li>
+          <a href="/docs/examples/template-content-page">
+            Content page
           </a>
         </li>
         <li>
           <a href="/docs/examples/task-list-page">
             Task list
-          </a>
-        </li>
-        <li>
-          <a href="/docs/examples/question-page">
-            Question
           </a>
         </li>
         <li>
@@ -154,6 +154,21 @@
           <a href="/docs/examples/confirmation-page">
             Confirmation
           </a>
+        </li>
+        <li>
+          Question pages
+          <ul class="list list-bullet">
+            <li>
+              <a href="/docs/examples/template-question-page-blank">
+                Blank
+              </a>
+            </li>
+            <li>
+              <a href="/docs/examples/question-page">
+                Date of birth
+              </a>
+            </li>
+          </ul>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Add two new template pages to the kit.

For links (back links, action urls, etc), I've gone with `href="/url/of/previous/page"`. Does this seem correct?

## Using POSTs

These templates work with #340 and start moving us towards using POSTs. That PR should probably get merged first.

## Template content page

A basic content page - useful for things like:
* eligible / ineligible pages
* 404 / error pages

Looks like:
![screen shot 2017-04-03 at 17 12 00](https://cloud.githubusercontent.com/assets/2204224/24619161/0d18331a-1891-11e7-9764-b9db80ef81ef.png)

## Template question page blank

A basic question page, containing:
* Heading
* Continue button
* Form element with POST method

Will be useful for people grabbing snippets from Elements.

Looks like:
![screen shot 2017-04-03 at 17 12 18](https://cloud.githubusercontent.com/assets/2204224/24619223/3a2f5252-1891-11e7-8aae-0237b83887bd.png)

