### PR TITLE
add page_scripts block

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -47,6 +47,9 @@
 {% endblock %}
 
 {% block body_end %}
-  {% include "includes/scripts.html" %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block page_scripts %}{% endblock %}
+  {% endblock %}
   <!-- GOV.UK Prototype kit {{releaseVersion}} -->
 {% endblock %}


### PR DESCRIPTION
add `page_scripts` and `scripts` blocks - to allow people to add new scripts, or replace all scripts, on a per-page basis