### PR TITLE
PaaS improvements

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.sass-cache
+.DS_Store
+.start.pid
+.port.tmp
+public
+lib/govuk_template.html
+govuk_modules
+node_modules/*
+.tmuxp.*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
       console.log('Username or password is not set.')
-      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
+      return res.send('<h1>Error: Username or password not set.</h1><p>All prototypes should be protected from accidental discovery by the public. Your prototype will not be fully visible online until a username and password for basic authentication have been added. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
     }
 
     var user = basicAuth(req)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
       console.log('Username or password is not set.')
-      return res.send('<h1>Error: Username or password not set.</h1><p>All prototypes should be protected from accidental discovery by the public. Your prototype will not be fully visible online until a username and password for basic authentication have been added. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
+      return res.send('<h1>Error: username or password not set.</h1><p>All prototypes should be protected from accidental discovery by the public when published online.</p> <p>The GOV.UK prototype kit will not make your work visible online until you&apos;ve added a username and password for basic authentication.</p> <p> <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for doing this</a>.</p>')
     }
 
     var user = basicAuth(req)


### PR DESCRIPTION
The PaaS team are conducting user research with the prototype kit.

We've found that the error message when basic auth hasn't been set isn't as helpful as it could be. We've not yet added a PaaS-specific error link, but hope to do that later once our own docs are ready for release. We would dearly like to test the new version of this error text with users in Newcastle next week.

We also found performance improvements by copying .gitignore to .cfignore - this prevented node.js dependencies being uploaded to PaaS by the user **and** then downloaded as part of the buildpack process on PaaS. Staging times were approximately halved for an unmodified prototyping kit as a result. This change should only affect Cloud Foundry users.

