### PR TITLE
Add .env file to support storing private data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .sass-cache
 .DS_Store
 .start.pid

--- a/lib/template.env
+++ b/lib/template.env
@@ -1,0 +1,20 @@
+# =========================================
+# WARNING: Don't commit this file to git
+# =========================================
+#
+# Use this file for storing private data - things like API keys and admin credentials
+#
+# Storing data:
+#
+# EXAMPLE_API_KEY=123456789
+# JSON={"foo": "bar"}
+#
+# More examples here: https://www.npmjs.com/package/dotenv
+#
+# Use the data in your app:
+#
+# var key = process.env.EXAMPLE_API_KEY
+
+# =========================================
+# INSERT YOUR DATA HERE:
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "cross-spawn": "^5.0.0",
+    "dotenv": "^4.0.0",
     "express": "4.13.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 var crypto = require('crypto')
 var path = require('path')
 var express = require('express')

--- a/start.js
+++ b/start.js
@@ -3,9 +3,19 @@
 var path = require('path')
 var fs = require('fs')
 
-if (!fs.existsSync(path.join(__dirname, '/node_modules'))) {
+// Check if node_modules folder exists
+const nodeModulesExists = fs.existsSync(path.join(__dirname, '/node_modules'))
+if (!nodeModulesExists) {
   console.error('ERROR: Node module folder missing. Try running `npm install`')
   process.exit(0)
+}
+
+// Create template .env file if it doesn't exist
+const envExists = fs.existsSync(path.join(__dirname, '/.env'))
+if (!envExists) {
+  console.log('Creating template .env file')
+  fs.createReadStream(path.join(__dirname, '/lib/template.env'))
+  .pipe(fs.createWriteStream(path.join(__dirname, '/.env')))
 }
 
 // run gulp


### PR DESCRIPTION
Add a `.env` file for storing private data. 

This is created from a template - so the real `.env` doesn't get committed to git.

This will be useful for teams integrating with APIs - like Notify.