### PR TITLE
Fix JS error in Safari’s Private Browsing mode

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,12 +2,8 @@
 /* global GOVUK */
 
 // Warn about using the kit in production
-if (
-  window.sessionStorage && window.sessionStorage.getItem('prototypeWarning') !== 'false' &&
-  window.console && window.console.info
-) {
+if (window.console && window.console.info) {
   window.console.info('GOV.UK Prototype Kit - do not use for production')
-  window.sessionStorage.setItem('prototypeWarning', true)
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
Safari in Private Browsing mode sets a session storage quota of 0 which means that attempts to write to it result in a QuotaExceededError being thrown, breaking JavaScript on the rest of the page.

The existing code is flawed in that it sets `prototypeWarning` to true but tests for 'false', so the warning is already shown on every page anyway.

As such, this simplifies it to remove the use of session storage entirely.