### PR TITLE
Upgrade node.js version for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.1.0",
   "private": true,
   "engines": {
-    "node": ">=6.0 <7.0"
+    "node": ">=6.11.1 <7.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
The Node.js team has announced that a high severity remote Denial of
Service (DoS) Constant Hashtable Seeds vulnerability in Node.js
versions 4.x through 8.x has been patched in the following versions:
6.11.1

`heroku run node -v -a govuk-prototype-kit` 6.11.0.