### PR TITLE
Support deprecated check-your-answers table styles

### DIFF
--- a/app/assets/sass/patterns/_check-your-answers.scss
+++ b/app/assets/sass/patterns/_check-your-answers.scss
@@ -1,4 +1,4 @@
-
+// Recommended - Use these styles for the check your answers pattern
 .govuk-check-your-answers {
 
   @include media(desktop) {
@@ -79,4 +79,17 @@
     }
   }
 
+}
+
+// Deprecated - these styles will be removed in a later release
+.check-your-answers {
+  td {
+    @include core-19;
+    vertical-align: top;
+  }
+  .change-answer {
+    text-align: right;
+    font-weight: bold;
+    padding-right: 0;
+  }
 }


### PR DESCRIPTION
To ensure we support existing prototypes using the old check your
answers pattern - where using a table was recommended, add the styles
back in - but mark these as deprecated.

These were removed in #365.

As the new check-your-answers styles are namespaced using `.govuk-` these are opt-in, so we
can release without making a breaking change.

In future, we can remove `.check-your-answers`, the next time we make a
breaking change to the prototype kit.