### PR TITLE
Copyright should be Crown Copyright

### DIFF
--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -1,4 +1,6 @@
-Copyright (C) 2014 HM Government (Government Digital Service)
+The MIT License
+
+Copyright (C) 2014 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Also, it should include the title "The MIT License" so people can see what it is. See our guidance: https://github.com/alphagov/styleguides/blob/master/licensing.md