### PR TITLE
fix(package): update govuk_template_jinja to version 0.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-writer": "0.0.4",
     "govuk-elements-sass": "3.0.1",
     "govuk_frontend_toolkit": "7.0.0",
-    "govuk_template_jinja": "0.22.2",
+    "govuk_template_jinja": "0.22.3",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-mocha": "^4.3.1",


### PR DESCRIPTION
# 0.22.3

- Fix the Django package – ensure setuptools uses the MANIFEST.in by setting the include_package_data flag to True, and fix a broken download link ([PR #319](https://github.com/alphagov/govuk_template/pull/319)).
