### PR TITLE
Disable package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib/govuk_template.html
 govuk_modules
 node_modules/*
 .tmuxp.*
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Currently after `npm install`, npm tells users that a package-lock file has been created and they should commit it. This functionality has caused problems for many people, including our own projects at GDS.

This PR disables package lock, so npm continues to function in the way it has in the past.

See more here: https://codeburst.io/disabling-package-lock-json-6be662f5b97d