### PR TITLE
Update testing matrix to test against latest LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- 4.0
-- 6.0
+- "lts/*"
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
 before_install:


### PR DESCRIPTION
Stop testing against Node 4.0, and test against the latest LTS instead.