### PR TITLE
DO NOT MERGE - Fix docs images on github

### DIFF
--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -12,7 +12,7 @@ We recommend keeping all your prototypes in one folder called `projects`.
 
 Create a folder called `projects` in your home folder. You can open your home folder by opening a new finder window, and selecting `go > home` from the top menu.
 
-![Screenshot of a 'projects' folder in the mac home folder](/public/images/docs/mac-home-folder-projects.png)
+![Screenshot of a 'projects' folder in the mac home folder](../../assets/images/docs/mac-home-folder-projects.png)
 
 #### Windows users
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -97,7 +97,7 @@ xcode-select --install
 ```
 If you already have command line tools, this will display `xcode-select: error: command line tools are already installed, use "Software Update" to install updates`.
 
-![Screenshot of Command line tools popup message](/public/images/docs/installing-mavericks-popup.png)
+![Screenshot of Command line tools popup message](../../assets/images/docs/installing-mavericks-popup.png)
 
 If you don’t have command line tools, it will open an installer. Follow the instructions to install the command line tools.
 

--- a/docs/documentation/install/run-the-kit.md
+++ b/docs/documentation/install/run-the-kit.md
@@ -24,7 +24,7 @@ In your web browser, visit <a href="http://localhost:3000" target="_blank">http:
 
 You should see the prototype welcome page.
 
-![Screenshot of the prototype kit homepage](/public/images/docs/prototype-kit-homepage.png)
+![Screenshot of the prototype kit homepage](../../assets/images/docs/prototype-kit-homepage.png)
 
 ## Quitting the kit
 

--- a/server.js
+++ b/server.js
@@ -97,6 +97,8 @@ if (useDocumentation) {
 
   // Set views engine
   documentationApp.set('view engine', 'html')
+
+  app.use('/assets', express.static(path.join(__dirname, '/docs/assets')))
 }
 
 // Support for parsing data in POSTs


### PR DESCRIPTION
This fixes the images on Github (#283)  by:

 - using a relative path for the images
 - adding `/docs/assets` to the static server path when documentation is turned on

I'm not sure this is worth merging though. We're adding complexity to the app, in order to have images work on Github. The primary place to view the documentation is on the prototype kit, so I worry about adding complexity in order to view the documentation in two places. I think supporting both will give us extra work going forward.