### PR TITLE
DO NOT MERGE Add nocache module to prevent browser caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-util": "^3.0.7",
     "marked": "^0.3.6",
     "minimist": "1.2.0",
+    "nocache": "^2.0.0",
     "notifications-node-client": "^3.0.0",
     "nunjucks": "^2.5.2",
     "portscanner": "^2.1.1",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ var crypto = require('crypto')
 var path = require('path')
 var express = require('express')
 var session = require('express-session')
+var nocache = require('nocache')
 var nunjucks = require('nunjucks')
 var routes = require('./app/routes.js')
 var documentationRoutes = require('./docs/documentation_routes.js')
@@ -50,6 +51,11 @@ if (isSecure) {
   app.use(utils.forceHttps)
   app.set('trust proxy', 1) // needed for secure cookies on heroku
 }
+
+// prevent browser from caching responses, so users of the kit always see
+// their latest changes
+
+app.use(nocache())
 
 // Authenticate against the environment-provided credentials, if running
 // the app in production (Heroku, effectively)


### PR DESCRIPTION
this fixes #363 

to test:

1. add a link from index.html to /test
2. add a route:

```
router.get('/test', function (req, res) {
  res.send('test')
})
```

3. In the browser, click the link on the index page
4. Press back button in the browser
5. Change the route to respond with 'test2'
6. Press forward in the browser

With the fix, you see the new response. Without the fix you see the old (cached) response.