### PR TITLE
[do not merge] use express-nunjucks so we just have 1 nunjucks environment

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -233,3 +233,40 @@ exports.autoStoreData = function (req, res, next) {
 
   next()
 }
+
+exports.addCheckedFunction = function (nunjucksEnv) {
+  // add nunjucks function called 'checked' to populate radios and checkboxes,
+  // needs to be here as it needs access to req.session and nunjucks environment
+  return function (req, res, next) {
+    nunjucksEnv.addGlobal('checked', function (name, value) {
+      // check session data exists
+      if (req.session.data === undefined) {
+        return ''
+      }
+
+      var storedValue = req.session.data[name]
+
+      // check the requested data exists
+      if (storedValue === undefined) {
+        return ''
+      }
+
+      var checked = ''
+
+      // if data is an array, check it exists in the array
+      if (Array.isArray(storedValue)) {
+        if (storedValue.indexOf(value) !== -1) {
+          checked = 'checked'
+        }
+      } else {
+        // the data is just a simple value, check it matches
+        if (storedValue === value) {
+          checked = 'checked'
+        }
+      }
+      return checked
+    })
+
+    next()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cross-spawn": "^5.0.0",
     "dotenv": "^4.0.0",
     "express": "4.15.2",
+    "express-nunjucks": "^2.2.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "3.1.1",


### PR DESCRIPTION
If we use the `express-nunjucks` module, it cleans up the server code. We only need one nunjucks environment instead of two, and we don't need `app.set('view engine', 'html')`

Ignore the work to move checkedFunction to utils, thats being done in the other PR.