### PR TITLE
De-duplicate code to stop search indexing

### DIFF
--- a/server.js
+++ b/server.js
@@ -140,18 +140,6 @@ if (useAutoStoreData === 'true') {
   utils.addCheckedFunction(nunjucksDocumentationEnv)
 }
 
-// Disallow search index idexing
-app.use(function (req, res, next) {
-  // Setting headers stops pages being indexed even if indexed pages link to them.
-  res.setHeader('X-Robots-Tag', 'noindex')
-  next()
-})
-
-app.get('/robots.txt', function (req, res) {
-  res.type('text/plain')
-  res.send('User-agent: *\nDisallow: /')
-})
-
 app.get('/prototype-admin/clear-data', function (req, res) {
   req.session.destroy()
   res.render('prototype-admin/clear-data')


### PR DESCRIPTION
This code runs twice - once for all apps, then again in the check for `promoMode`. I've deleted the first instance.

https://github.com/alphagov/govuk_prototype_kit/blob/master/server.js#L174-L184