### PR TITLE
Adding express validator to the govuk prototype kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^4.0.0",
     "express": "4.15.2",
     "express-session": "^1.13.0",
+    "express-validator": "^4.2.1",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "3.1.1",
     "govuk_frontend_toolkit": "7.1.0",

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const express = require('express')
 const favicon = require('serve-favicon')
 const nunjucks = require('nunjucks')
 const session = require('express-session')
+const validator = require('express-validator')
 
 // Local dependencies
 const config = require('./app/config.js')
@@ -84,6 +85,9 @@ app.use('/public/images/icons', express.static(path.join(__dirname, '/govuk_modu
 
 // Elements refers to icon folder instead of images folder
 app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images', 'favicon.ico')))
+
+// Express middleware for validation
+app.use(validator())
 
 // Set up documentation app
 if (useDocumentation) {


### PR DESCRIPTION
# Express Validator
----
Implementing [express-validator](https://github.com/ctavan/express-validator) to allow for easier validation within routes.
---- 
## Example usage  
Element being checked  
`<input id="radio-id" type="radio" name="getHelp" value="radio-value">`
  
In the routes:
```
req.check('getHelp', 'Confirm what you want to tell us').notEmpty()
const errors = req.validationErrors()  
if (errors) {  
  res.render('pageurl', { errors })  
} else {
  res.redirect('pageurl')
}
```
In the HTML:  
```
{% if errors %}
  <div class="error-summary">
    <h2 class="heading-medium error-summary-heading">There is a problem</h2>
      <ul class="error-summary-list">
        <li><a href="#confirm-help">{{ error.msg }}</a></li>
      </ul>
  </div>
{% endif %}
```
In this example it is to check whether or not radio button has been selected, however the library has the flexibility to test for different form elements and under different circumstances. 