### PR TITLE
Add Google tag manager tracking

### DIFF
--- a/docs/views/includes/tracking_body.html
+++ b/docs/views/includes/tracking_body.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{gtmId}}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/docs/views/includes/tracking_head.html
+++ b/docs/views/includes/tracking_head.html
@@ -1,0 +1,7 @@
+<!--  Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{gtmId}}');</script>
+<!-- End Google Tag Manager -->

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -2,7 +2,18 @@
 
 {% block head %}
   {% include "includes/head.html" %}
+  {% if promoMode == 'true' and gtmId %}
+    {% include "includes/tracking_head.html" %}
+  {% endif %}
 {% endblock %}
+
+
+{% block body_start %}
+  {% if promoMode == 'true' and gtmId %}
+    {% include "includes/tracking_body.html" %}
+  {% endif %}
+{% endblock %}
+
 
 {% block cookie_message %}
   <p>{{cookieText | safe }}</p>

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreDat
 var useHttps = process.env.USE_HTTPS || config.useHttps
 var useBrowserSync = config.useBrowserSync
 var analyticsId = process.env.ANALYTICS_TRACKING_ID
+var gtmId = process.env.GOOGLE_TAG_MANAGER_TRACKING_ID
 
 env = env.toLowerCase()
 useAuth = useAuth.toLowerCase()
@@ -110,6 +111,7 @@ app.use(bodyParser.urlencoded({
 
 // Add variables that are available in all views
 app.locals.analyticsId = analyticsId
+app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = (useAutoStoreData === 'true')
 app.locals.cookieText = config.cookieText


### PR DESCRIPTION
Adding Google Tag Manager as per Design System [Trello ticket](https://trello.com/c/47shVijF/404-implement-google-tag-manager-on-the-prototype-kit)
Follows current analytics implementation, gtm code added to heroku config vars 