### PR TITLE
Add markdown tag to nunjucks

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,6 +6,9 @@ $path: "/public/images/";
 // Take a look in /govuk-modules/_govuk-elements.scss to see which files are imported.
 @import 'govuk-elements';
 
+// Import styles from the docs stylesheet for styling markdown rendered elements
+@import '../../../docs/assets/sass/docs';
+
 // Take a look at in app/assets/sass/patterns/ to see which files are imported.
 @import 'patterns/check-your-answers';
 @import 'patterns/task-list';

--- a/lib/nunjucks_markdown.js
+++ b/lib/nunjucks_markdown.js
@@ -51,7 +51,7 @@ function MarkdownContent () {
       body = body.join('\n')
     }
 
-    return new nunjucks.runtime.SafeString('<div class="docs markdown">' + marked(body) + '</div>')
+    return new nunjucks.runtime.SafeString('<div class="markdown">' + marked(body) + '</div>')
   }
 }
 

--- a/lib/nunjucks_markdown.js
+++ b/lib/nunjucks_markdown.js
@@ -1,0 +1,31 @@
+var nunjucks = require('nunjucks')
+var marked = require('marked')
+
+function MarkdownContent () {
+  this.tags = ['markdown']
+
+  this.parse = function (parser, nodes, lexer) {
+    var token = parser.nextToken()
+    var args = parser.parseSignature(null, true)
+
+    parser.advanceAfterBlockEnd(token.value)
+
+    var body = parser.parseUntilBlocks('error', 'endmarkdown')
+    var errorBody = null
+
+    if (parser.skipSymbol('error')) {
+      parser.skip(lexer.TOKEN_BLOCK_END)
+      errorBody = parser.parseUntilBlocks('endmarkdown')
+    }
+
+    parser.advanceAfterBlockEnd()
+
+    return new nodes.CallExtension(this, 'run', args, [body, errorBody])
+  }
+
+  this.run = function (context, body, errorBody) {
+    return new nunjucks.runtime.SafeString('<div class="docs markdown">' + marked(body()) + '</div>')
+  }
+}
+
+module.exports = MarkdownContent

--- a/lib/nunjucks_markdown.js
+++ b/lib/nunjucks_markdown.js
@@ -1,30 +1,57 @@
-var nunjucks = require('nunjucks')
-var marked = require('marked')
+const nunjucks = require('nunjucks')
+const marked = require('marked')
 
 function MarkdownContent () {
   this.tags = ['markdown']
 
   this.parse = function (parser, nodes, lexer) {
-    var token = parser.nextToken()
-    var args = parser.parseSignature(null, true)
+    let token = parser.nextToken()
+    let args = parser.parseSignature(null, true)
 
     parser.advanceAfterBlockEnd(token.value)
 
-    var body = parser.parseUntilBlocks('error', 'endmarkdown')
-    var errorBody = null
+    let body = parser.parseUntilBlocks('error', 'endmarkdown')
+    let errorBody = null
 
     if (parser.skipSymbol('error')) {
       parser.skip(lexer.TOKEN_BLOCK_END)
       errorBody = parser.parseUntilBlocks('endmarkdown')
     }
 
+    let tabStart = new nodes.NodeList(0, 0, [new nodes.Output(0, 0, [new nodes.TemplateData(0, 0, (token.colno - 1))])])
+
     parser.advanceAfterBlockEnd()
 
-    return new nodes.CallExtension(this, 'run', args, [body, errorBody])
+    return new nodes.CallExtension(this, 'run', args, [body, errorBody, tabStart])
   }
 
-  this.run = function (context, body, errorBody) {
-    return new nunjucks.runtime.SafeString('<div class="docs markdown">' + marked(body()) + '</div>')
+  this.run = function (context, body, errorBody, tabStart) {
+    let spacesRegex = /^[\s]+/
+
+    tabStart = tabStart()
+    body = body()
+
+    // Normalise the content indentation to the {% markdown %} tag depth
+    // Credit to https://github.com/zephraph/nunjucks-markdown/blob/master/lib/markdown_tag.js
+    if (tabStart > 0) {
+      body = body.split(/\r?\n/)
+
+      body = body.map(function (line) {
+        let startSpaces = line.match(spacesRegex)
+
+        if (startSpaces && startSpaces[0].length >= tabStart) {
+          return line.slice(tabStart)
+        } else if (startSpaces) {
+          return line.slice(startSpaces[0].length)
+        } else {
+          return line
+        }
+      })
+
+      body = body.join('\n')
+    }
+
+    return new nunjucks.runtime.SafeString('<div class="docs markdown">' + marked(body) + '</div>')
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const documentationRoutes = require('./docs/documentation_routes.js')
 const packageJson = require('./package.json')
 const routes = require('./app/routes.js')
 const utils = require('./lib/utils.js')
+const MarkdownContent = require('./lib/nunjucks_markdown')
 
 const app = express()
 const documentationApp = express()
@@ -70,6 +71,9 @@ var nunjucksAppEnv = nunjucks.configure(appViews, {
   noCache: true,
   watch: true
 })
+
+// add markdown tag to nunjucks
+nunjucksAppEnv.addExtension('markdown', new MarkdownContent())
 
 // Add Nunjucks filters
 utils.addNunjucksFilters(nunjucksAppEnv)


### PR DESCRIPTION
This tag allows the use of markdown with nunjucks templates. You can use the tag as below:

```
{% markdown %}
# heading 1
## heading 2

I am a piece of a text with a [link](https://www.gov.uk/)
{% endmarkdown %}
```

The content of the tag has to be at the same indentation as the tag itself, in order to be rendered correctly.

This allows whomever is working on the templates to use markdown where they like.

At the moment, in order to style elements generated by markdown (we can't add classes directly) I am importing the stylesheet from the documentation assets.