### PR TITLE
Add meta description for better descriptions in Google

### DIFF
--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -1,3 +1,5 @@
+<meta name="description" content="Use the GOV.UK Prototype Kit to quickly make realistic HTML prototypes of GOV.UK services.">
+
 <!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
 <!--[if lte IE 8]><link href="/public/stylesheets/docs-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->


### PR DESCRIPTION
At the moment when you search for the kit online the description is not very useful.

This adds a meta tag to ensure a defined description is shown.

## Current description

<img width="639" alt="screen shot 2018-01-30 at 17 09 21" src="https://user-images.githubusercontent.com/2445413/35580215-5dba9aa0-05e0-11e8-8326-c82d6e4bee38.png">

## Source example after change
<img width="1113" alt="screen shot 2018-01-30 at 17 03 04" src="https://user-images.githubusercontent.com/2445413/35580229-6962111c-05e0-11e8-9744-385be042a0ed.png">

As part of https://trello.com/c/87WZ8ffS/212-fix-prototype-kit-description-in-google