### PR TITLE
Add default session data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+New features:
+
+- [#501 Add default session data](https://github.com/alphagov/govuk_prototype_kit/pull/501)
+
 Bug fixes:
 
 - [#491 Remove redundant Google Analytics](https://github.com/alphagov/govuk_prototype_kit/pull/491)

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,0 +1,24 @@
+/*
+
+Provide default values for user session data. These are automatically added
+via the `autoStoreData` middleware. Values will only be added to the
+session if a value doesn't already exist. This may be useful for testing
+journeys where users are returning or logging in to an existing application.
+
+============================================================================
+
+Example usage:
+
+"full-name": "Sarah Philips",
+
+"options-chosen": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Insert values here
+
+}

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -94,6 +94,18 @@
 </div>
       </pre>
 
+      <h3 class="heading-small">
+        Setting default data
+      </h3>
+
+      <p>You can set default values in this file in your prototype folder:
+      <pre>
+<div class="code">
+  app/data/session-data-defaults.js
+
+</div>
+      </pre>
+
       <h2 class="heading-medium">Advanced features</h2>
 
       <h3 class="heading-small">

--- a/lib/template.session-data-defaults.js
+++ b/lib/template.session-data-defaults.js
@@ -1,0 +1,24 @@
+/*
+
+Provide default values for user session data. These are automatically added
+via the `autoStoreData` middleware. Values will only be added to the
+session if a value doesn't already exist. This may be useful for testing
+journeys where users are returning or logging in to an existing application.
+
+============================================================================
+
+Example usage:
+
+"full-name": "Sarah Philips",
+
+"options-chosen": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Insert values here
+
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,11 +252,24 @@ var storeData = function (input, store) {
   }
 }
 
+// Get session default data from file
+let sessionDataDefaults = {}
+
+const sessionDataDefaultsFile = path.join(__dirname, '/../app/data/session-data-defaults.js')
+
+try {
+  sessionDataDefaults = require(sessionDataDefaultsFile)
+} catch (e) {
+  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?')
+}
+
 // Middleware - store any data sent in session, and pass it to all views
 exports.autoStoreData = function (req, res, next) {
   if (!req.session.data) {
     req.session.data = {}
   }
+
+  req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
 
   storeData(req.body, req.session)
   storeData(req.query, req.session)

--- a/start.js
+++ b/start.js
@@ -17,6 +17,21 @@ if (!envExists) {
   .pipe(fs.createWriteStream(path.join(__dirname, '/.env')))
 }
 
+// Create template session data defaults file if it doesn't exist
+const dataDirectory = path.join(__dirname, '/app/data')
+const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js')
+const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile)
+
+if (!sessionDataDefaultsFileExists) {
+  console.log('Creating session data defaults file')
+  if (!fs.existsSync(dataDirectory)) {
+    fs.mkdirSync(dataDirectory)
+  }
+
+  fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
+  .pipe(fs.createWriteStream(sessionDataDefaultsFile))
+}
+
 // Run gulp
 const spawn = require('cross-spawn')
 


### PR DESCRIPTION
By @mikeshawdev

If provided, the app will try to merge data from a defaults file with data from the session. Defaults will only apply if there isn't a corresponding value already in the session, so data can be overridden within the prototype if necessary.