### PR TITLE
Add cookies and privacy policy pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ Bug fixes:
 
 - [#491 Remove redundant Google Analytics](https://github.com/alphagov/govuk_prototype_kit/pull/491)
 
+New features:
+- [#502 Add Cookies and Privacy policy text](https://github.com/alphagov/govuk_prototype_kit/pull/502)
+
 # 6.3.0
 
 New features:
-
 - [#430 Recommend Atom over Sublime text](https://github.com/alphagov/govuk_prototype_kit/pull/430)
 - [#415 Update to govuk-elements-sass v3.1.1](https://github.com/alphagov/govuk_prototype_kit/pull/415)
 - [#422 fix(package): update govuk_template_jinja to version 0.22.3](https://github.com/alphagov/govuk_prototype_kit/pull/422)

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -50,3 +50,10 @@
 	}
 }
 
+.app-table--fixed {
+  table-layout: fixed;
+}
+
+.app-\!-db {
+  display: block !important;
+}

--- a/docs/views/cookies.html
+++ b/docs/views/cookies.html
@@ -1,0 +1,119 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+About - GOV.UK Prototype kit
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="breadcrumbs">
+        <ol>
+          <li><a href="/docs">GOV.UK prototype kit</a></li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">Cookies</h1>
+
+      <p>The GOV.UK Prototype Kit puts small files (known as ‘cookies’) on to your computer.</p>
+
+      <p>We use cookies to:</p>
+
+      <ul class="list list-bullet">
+        <li>record the notifications you&#39;ve seen so we don&#39;t show them again</li>
+        <li>measure how you use the website so it can be updated and improved based on your activity</li>
+      </ul>
+
+      <p>These cookies aren’t used to identify you personally.</p>
+
+      <p>You’ll see a message on the site before we store a cookie on your computer.</p>
+
+      <p><a href="https://ico.org.uk/for-the-public/online/cookies/">Find out how to manage cookies.</a></p>
+
+      <h2 class="heading-large">Our cookie message</h2>
+
+      <p>You will see a message about cookies when you first visit the GOV.UK Prototype Kit. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+
+      <table class="app-table--fixed">
+
+        <caption class="visually-hidden">Dates and amounts</caption>
+
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Purpose</th>
+            <th scope="col">Expires</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>seen_cookie_message</td>
+            <td>Saves a message to let us know that you have seen our cookie message</td>
+            <td>28 days</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 class="heading-large">Measuring website usage with Google Analytics</h2>
+
+      <p>We use Google Analytics software to collect information about how you use the GOV.UK Prototype Kit. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+
+      <p>Google Analytics stores information about:</p>
+
+      <ul class="list list-bullet">
+        <li>the pages you visit</li>
+        <li>how long you spend on each page</li>
+        <li>how you got to the site</li>
+        <li>what you click on while you’re visiting the site.</li>
+      </ul>
+
+      <p>We don’t collect or store your personal information, so this data can’t be used to identify who you are. For more information visit our <a href="/docs/privacy-policy">privacy policy</a> page.</p>
+
+      <p>We don’t allow Google to use or share our analytics data.</p>
+
+      <p>Google Analytics sets the following cookies:</p>
+
+      <table class="app-table--fixed">
+
+        <caption class="visually-hidden">Dates and amounts</caption>
+
+
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Purpose</th>
+            <th scope="col">Expires</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>_ga</td>
+            <td>This helps us count how many people visit the GOV.UK Prototype Kit site by tracking if you’ve visited before</td>
+            <td>2 years</td>
+          </tr>
+          <tr>
+            <td>_gid</td>
+            <td>This helps us count how many people visit the GOV.UK Prototype Kit site by tracking if you’ve visited before</td>
+            <td>24 hours</td>
+          </tr>
+          <tr>
+            <td>_gat</td>
+            <td>This is used to limit the rate at which page view requests are recorded by Google</td>
+            <td>1 minute</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -49,13 +49,19 @@
 {% endblock %}
 
 {% block footer_support_links %}
-  {% if useAutoStoreData %}
-    <ul>
-      <li>
-        <a href="/prototype-admin/clear-data">Clear data</a>
-      </li>
-    </ul>
-  {% endif %}
+  <ul class="app-!-db">
+    <li>
+      <a href="/prototype-admin/clear-data">Clear data</a>
+    </li>
+  </ul>
+  <ul>
+    <li>
+      <a href="/docs/cookies">Cookies</a>
+    </li>
+    <li>
+      <a href="/docs/privacy-policy">Privacy policy</a>
+    </li>
+  </ul>
 {% endblock %}
 
 {% block body_end %}

--- a/docs/views/privacy-policy.html
+++ b/docs/views/privacy-policy.html
@@ -1,0 +1,84 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+About - GOV.UK Prototype kit
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="breadcrumbs">
+        <ol>
+          <li><a href="/docs">GOV.UK prototype kit</a></li>
+        </ol>
+      </div>
+    </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">Privacy policy</h1>
+
+      <p>We collect certain information and data about you when you use the GOV.UK Prototype Kit.</p>
+
+      <p>We collect:</p>
+
+      <ul class="list list-bullet">
+        <li>questions, queries or feedback you leave</li>
+        <li>your email address, if you contact us</li>
+        <li>your Internet Protocol (IP) address, and which version of web browser you used</li>
+        <li>information on how you use the site, using <a href="/docs/cookies">cookies</a> and page-tagging techniques</li>
+      </ul>
+
+      <p>This data can be viewed by authorised people in the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a> (GDS) and our suppliers, to:</p>
+
+      <ul class="list list-bullet">
+        <li>improve the site by monitoring how you use it</li>
+        <li>gather feedback to improve our services</li>
+        <li>respond to any feedback you send us, if you’ve asked us to.</li>
+      </ul>
+
+      <h2 class="heading-large">Where your data is stored</h2>
+
+      <p>We store your data on secure servers in the <a href="https://www.gov.uk/eu-eea">European Economic Area</a> (EEA).</p>
+
+      <h2 class="heading-large">Keeping your data secure</h2>
+
+      <p>Sending information over the internet is generally not completely secure, and we can’t guarantee the security of your data while it’s in transit.</p>
+
+      <p><strong>Any data you send is at your own risk</strong>.</p>
+
+      <p>We have procedures and security features in place to keep your data secure once we receive it.</p>
+
+      <h2 class="heading-large">Disclosing your information</h2>
+
+      <p>We may pass on your personal information if we have a legal obligation to do so, or if we have to enforce or apply our <a href="https://www.gov.uk/help/terms-conditions">terms of use</a> and other agreements. This includes exchanging information with other government departments for legal reasons.</p>
+
+      <p>We won’t share your information with any other organisations for marketing, market research or commercial purposes, and we don’t pass on your details to other websites.</p>
+
+      <h2 class="heading-large">Your rights</h2>
+
+      <p>You can <a href="https://www.gov.uk/data-protection">find out what information we hold about you</a>, and <a href="https://www.gov.uk/contact">ask us not to use any of the information we collect</a>.</p>
+
+      <h2 class="heading-large">Links to other websites</h2>
+
+      <p>The GOV.UK Prototype Kit contains links to other websites.</p>
+
+      <p>This privacy policy only applies to the GOV.UK Prototype Kit, and doesn’t cover other government services and transactions that we link to. These services have their own terms and conditions and privacy policies.</p>
+
+      <h3 class="heading-medium">Following a link to another website</h3>
+
+      <p>If you go to another website from this one, read the privacy policy on that website to find out what it does with your information.</p>
+
+      <h3 class="heading-medium">Following a link to the GOV.UK Prototype Kit from another website</h3>
+
+      <p>If you come to the GOV.UK Prototype Kit from another website, we may receive information from the other website. We don’t use this data. You should read the privacy policy of the website you came from to find out more about this.</p>
+
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/server.js
+++ b/server.js
@@ -147,6 +147,8 @@ app.get('/prototype-admin/clear-data', function (req, res) {
 if (promoMode === 'true') {
   console.log('Prototype kit running in promo mode')
 
+  app.locals.cookieText = 'GOV.UK uses cookies to make the site simpler. <a href="/docs/cookies">Find out more about cookies</a>'
+
   app.get('/', function (req, res) {
     res.redirect('/docs')
   })


### PR DESCRIPTION
This PR replicates the (already merged) Cookies and Privacy policy pages on the beta version of the prototype kit.

This change:
- Adds a cookies page
- Adds a privacy policy page
- Add links to cookies and privacy policy on the footer for the website (They will not appear in the footer for prototypes created with the kit)
- Creates a link to the cookies page in the cookie banner when in promo mode

In addition there are some docs specific styles for `table: fixed` and an override for `display: block` in order to style these pages in the same way as on the beta version of the kit and the design system.