### PR TITLE
Do not track users who have enabled 'DoNotTrack'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 New features:
 
 - [#501 Add default session data](https://github.com/alphagov/govuk_prototype_kit/pull/501)
+- [#502 Add Cookies and Privacy policy text](https://github.com/alphagov/govuk_prototype_kit/pull/502)
+- [#521 Do not track users who have enabled 'DoNotTrack'](https://github.com/alphagov/govuk_prototype_kit/pull/521)
 
 Bug fixes:
 
 - [#491 Remove redundant Google Analytics](https://github.com/alphagov/govuk_prototype_kit/pull/491)
-
-New features:
-- [#502 Add Cookies and Privacy policy text](https://github.com/alphagov/govuk_prototype_kit/pull/502)
 
 # 6.3.0
 

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -24,14 +24,14 @@
 
 {% block head %}
   {% include "includes/head.html" %}
-  {% if promoMode == 'true' and gtmId %}
+  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
     {% include "includes/tracking_head.html" %}
   {% endif %}
 {% endblock %}
 
 
 {% block bodyStart %}
-  {% if promoMode == 'true' and gtmId %}
+  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
     {% include "includes/tracking_body.html" %}
   {% endif %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -123,6 +123,15 @@ app.use(bodyParser.urlencoded({
   extended: true
 }))
 
+// Add global variable to determine if DoNotTrack is enabled.
+// This indicates a user has explicitly opted-out of tracking.
+// Therefore we can avoid injecting third-party scripts that do not respect this decision.
+app.use(function (req, res, next) {
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT
+  app.locals.doNotTrackEnabled = (req.header('DNT') === '1')
+  next()
+})
+
 // Add variables that are available in all views
 app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'


### PR DESCRIPTION
Adds a guard around Google Tag Manager script to prevent it from initialising,
for users who have indicated they do not want to be tracked.

Cherry picked from https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/52

Closes https://github.com/alphagov/govuk_prototype_kit/issues/518