### PR TITLE
Add inline-code-block styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features:
 - [#501 Add default session data](https://github.com/alphagov/govuk_prototype_kit/pull/501)
 - [#502 Add Cookies and Privacy policy text](https://github.com/alphagov/govuk_prototype_kit/pull/502)
 - [#521 Do not track users who have enabled 'DoNotTrack'](https://github.com/alphagov/govuk_prototype_kit/pull/521)
+- [#522 Add inline-code block styles](https://github.com/alphagov/govuk_prototype_kit/pull/522)
 
 Bug fixes:
 

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -87,6 +87,12 @@
   pre {
     @extend .app-code;
   }
+  
+  p code {
+    border: 1px solid $govuk-border-colour;
+    background-color: govuk-colour("grey-4");
+    padding: 0 govuk-spacing(2);
+  }
 
   // TODO: Blockquotes are likely the most semantic element to be using, update to use the inset component directly.
   blockquote {


### PR DESCRIPTION
Block code highlight is already in there, so just added inline-block highlight.
Fixes: https://github.com/alphagov/govuk_prototype_kit/issues/517